### PR TITLE
ci: skip steps instead of whole workflow so required checks pass on docs-only changes

### DIFF
--- a/.github/workflows/node-version-compatibility.yml
+++ b/.github/workflows/node-version-compatibility.yml
@@ -6,16 +6,7 @@ on:
       - 'develop'
       - 'develop*'
     paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - 'agents/**'
-      - 'docs/**'
-      - 'documents/**'
       - '.gitignore'
-      - '.cspell.config.yaml'
-      - '.editorconfig'
-      - '.markdownlint-cli2.mjs'
-      - 'LICENSE'
 
   workflow_dispatch:
 
@@ -33,6 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Fetch main
+        run: git fetch origin main # To allow check-should-run-type-checks to get the diff from main
+
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -45,11 +39,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --engine-strict
 
+      # NOTE: To include this workflow in the branch protection rule status check,
+      # skip each step instead of skipping the entire workflow with paths-ignore.
+      - name: Check diff
+        id: check_diff_type
+        run: pnpm exec check-should-run-type-checks
+
       - name: Verify installation
+        if: steps.check_diff_type.outputs.should_run == 'true'
         run: pnpm list
 
       - name: Build
+        if: steps.check_diff_type.outputs.should_run == 'true'
         run: pnpm run build
 
       - name: Test
+        if: steps.check_diff_type.outputs.should_run == 'true'
         run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,21 +58,17 @@ jobs:
         id: check_diff_type
         run: pnpm exec check-should-run-type-checks
 
-      - name: Exit if no relevant changes
-        if: steps.check_diff_type.outputs.should_run != 'true'
-        run: exit 0
-
       - name: Install Playwright Browsers
-        if: matrix.command == 'test:browser'
+        if: steps.check_diff_type.outputs.should_run == 'true' && matrix.command == 'test:browser'
         run: pnpm exec playwright install chromium
 
       - name: Run "${{ matrix.command }}"
-        if: matrix.command != 'test:browser'
+        if: steps.check_diff_type.outputs.should_run == 'true' && matrix.command != 'test:browser'
         run: pnpm run ${{ matrix.command }}
 
       # Source - https://stackoverflow.com/a/71583518
       - name: Run 'test:browser' with retry
-        if: matrix.command == 'test:browser'
+        if: steps.check_diff_type.outputs.should_run == 'true' && matrix.command == 'test:browser'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10
@@ -80,7 +76,7 @@ jobs:
           command: pnpm run ${{ matrix.command }}
 
       - name: Upload coverage reports to Codecov
-        if: matrix.command == 'test:cov'
+        if: steps.check_diff_type.outputs.should_run == 'true' && matrix.command == 'test:cov'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary
The `test-node-versions (<version>)` jobs are required status checks in the main branch ruleset, but `node-version-compatibility.yml` was skipped entirely (via `paths-ignore`) on docs-only changes, leaving the required checks permanently pending and blocking merges. This mirrors the fix already applied in `ts-data-forge`.

## Changes

### `node-version-compatibility.yml`
- Removed the broad `paths-ignore` patterns (markdown, text, docs, agents, config files) so the workflow always runs and the required status checks always report (kept `.gitignore` only, matching `lint.yml`)
- Added `git fetch origin main` and a `check-should-run-type-checks` step that determines from the diff against main whether the checks need to run
- Gated the "Verify installation", "Build", and "Test" steps on `should_run == 'true'`, so docs-only pushes complete quickly with a successful check

### `test.yml`
- The "Exit if no relevant changes" step only ran `exit 0`, which ends that step successfully without skipping the rest of the job, so tests still ran in full on docs-only changes
- Replaced it with explicit `should_run` conditions on each subsequent step (Playwright install, test runs, Codecov upload), matching `lint.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAZE7Pfy1b3EgbWeEarKyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAZE7Pfy1b3EgbWeEarKyT)_