### PR TITLE
feat: report the closest union member in long-union validation errors

### DIFF
--- a/.changeset/union-validation-error-messages.md
+++ b/.changeset/union-validation-error-messages.md
@@ -1,0 +1,32 @@
+---
+'ts-fortress': minor
+---
+
+Make validation error messages more specific.
+
+When a value fails to match a union whose member listing is long, the error no
+longer lists every member. It now reports either the runtime type categories the
+union accepts (when no member's category matches the value) or the closest
+member — the one whose own validation produces the fewest errors — followed by
+that member's errors, so a discriminated union value with a single wrong field
+is explained by that field alone.
+
+Values too long to print are now described (`a string of length 50`) instead of
+being dropped, and for unions, enums and intersections the message states that
+the value matched none / not all of the members. `null`, arrays, `Map`s and
+`Set`s are named individually instead of the bare `object` that `typeof`
+reports for all of them.
+
+The closest member is the one with the lowest score, where a member scores the
+number of checks it failed minus the number it passed (keys for a record,
+elements for a tuple, one check otherwise). Counting errors alone would report a
+small unrelated member over the large one the value nearly satisfies.
+
+A union nested directly inside another union is now flattened into it, so
+`A | (B | C)` behaves as `A | B | C` when a member has to be picked for the
+error message. A `recursion` member answers the flattening check without
+running its definition, so it stays a single opaque member.
+
+When several members are equally close, they are all named and the first of
+them reports its errors, unless naming them would exceed the same length bound
+that governs the member listing.

--- a/packages/ts-fortress/documents/union-closest-member-heuristic.md
+++ b/packages/ts-fortress/documents/union-closest-member-heuristic.md
@@ -1,0 +1,209 @@
+## How a union picks the member to blame
+
+Design notes for the closest-member heuristic in `src/compose/union.mts`, and the scenarios the scoring rule was chosen against.
+
+### The problem
+
+When a value matches no member of a union, the obvious message lists every member. That works for `"red" | "green" | "blue"` and falls apart for anything wider:
+
+```text
+Error: expected one of <{ kind: "circle", radius: number }>, <{ kind: "square", size: number }>, <{ kind: "rectangle", width: number, height: number }> but <object> type value was passed.
+```
+
+The reader has to diff the value against three type names to find out that a single field was wrong. In practice a rejected value usually satisfies almost all of one member, so the useful message is that member's own errors. Once the `|`-joined member listing passes `UNION_MEMBER_LISTING_MAX_LENGTH` (60 characters), the union reports one member instead of all of them:
+
+```text
+Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle", radius: number }>, which failed as follows:
+Error at radius: expected <number> type but <string> type value "5" was passed.
+```
+
+That leaves one question, which is what this document is about: **which member is the closest one?**
+
+### The rule
+
+Selection runs in two steps.
+
+1. **Filter by runtime type category.** Keep the members whose default value has the same runtime type as the value (`string`, `number`, `array`, `Map`, `object`, …). No member accepted the value, so this can never discard a member that would have matched; it only decides who is worth reporting. If nothing survives, the union reports the categories it accepts instead of a member.
+2. **Score the survivors.** Each candidate is validated and scored as _failed checks − passed checks_ — lower is closer. Ties go to the member that passed more checks, and members equal on both are all named, with the first in declaration order reporting its errors (the same order `prune` and `fill` use).
+
+```ts
+const satisfiedCheckCount = Math.max(
+    0,
+    checkCountOf(memberType) - errors.length,
+);
+const score = errors.length - satisfiedCheckCount;
+```
+
+`checkCountOf` is how many checks a member performs on a value: the number of keys for a record, the number of elements for a tuple, and `1` for everything else, which either matches or does not.
+
+### The scenarios
+
+Every scenario below is real code, and the numbers are what the implementation computes. `failed` is the length of the member's own `ValidationError[]`, `checks` is `checkCountOf`, and `passed` is `checks - failed` clamped at zero.
+
+#### Scenario 1 — a discriminated union with one wrong field
+
+```ts
+const circle = record({ kind: literal('circle'), radius: number() });
+const square = record({ kind: literal('square'), size: number() });
+const rectangle = record({
+    kind: literal('rectangle'),
+    width: number(),
+    height: number(),
+});
+
+union([circle, square, rectangle]).validate({ kind: 'circle', radius: '5' });
+```
+
+| member      | failed | checks | passed | score | reported |
+| :---------- | -----: | -----: | -----: | ----: | :------- |
+| `circle`    |      1 |      2 |      1 |     0 | ✅       |
+| `square`    |      2 |      2 |      0 |     2 |          |
+| `rectangle` |      3 |      3 |      0 |     3 |          |
+
+```text
+Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle", radius: number }>, which failed as follows:
+Error at radius: expected <number> type but <string> type value "5" was passed.
+```
+
+The discriminant does the work: every other variant fails on `kind` _and_ on its own missing fields.
+
+#### Scenario 2 — a small unrelated member vs. a larger near-match
+
+```ts
+const config = record({
+    kind: literal('config'),
+    host: string(),
+    port: number(),
+});
+const note = record({ note: string() });
+
+union([config, note]).validate({
+    kind: 'config',
+    host: 5,
+    port: 'not a number',
+});
+```
+
+| member   | failed | checks | passed | score | reported |
+| :------- | -----: | -----: | -----: | ----: | :------- |
+| `config` |      2 |      3 |      1 |     1 | ✅       |
+| `note`   |      1 |      1 |      0 |     1 |          |
+
+This is the case plain error counting gets wrong: `note` fails one check and `config` fails two, yet the value is obviously an attempt at a `config`. Crediting passed checks puts them level at `1`, and the tie-break — more passed checks — picks `config`.
+
+#### Scenario 3 — a large member the value mostly satisfies
+
+```ts
+const account = record({
+    id: number(),
+    name: string(),
+    email: string(),
+    role: string(),
+    age: number(),
+});
+const label = record({ label: string() });
+
+union([account, label]).validate({
+    id: 1,
+    name: 'Ada',
+    email: 'ada@example.com',
+    role: 7,
+    age: 'unknown',
+});
+```
+
+| member    | failed | checks | passed | score | reported |
+| :-------- | -----: | -----: | -----: | ----: | :------- |
+| `account` |      2 |      5 |      3 |    −1 | ✅       |
+| `label`   |      1 |      1 |      0 |     1 |          |
+
+```text
+Error: the value did not match any of the 2 members of the union; the closest member type is <{ id: number, name: string, email: string, role: string, age: number }>, which failed as follows:
+Error at role: expected <string> type but <number> type value `7` was passed.
+Error at age: expected <number> type but <string> type value "unknown" was passed.
+```
+
+Reporting two real errors beats reporting one useless one (`missing required key "label"`), which is what error counting alone would have produced.
+
+#### Scenario 4 — the same members, a value that means neither
+
+```ts
+union([account, label]).validate({ id: 1 });
+```
+
+| member    | failed | checks | passed | score | reported |
+| :-------- | -----: | -----: | -----: | ----: | :------- |
+| `account` |      4 |      5 |      1 |     3 |          |
+| `label`   |      1 |      1 |      0 |     1 | ✅       |
+
+This is the mirror image of scenario 3 and the reason the scoring is _not_ a ratio. `account` is `4/5` wrong and `label` is `1/1` wrong, so a ratio would report `account` and dump four errors on the reader for a value that has one key. Subtracting keeps the absolute cost of being wrong in the score.
+
+#### Scenario 5 — nothing in the value points at a variant
+
+```ts
+union([circle, square, rectangle]).validate({});
+```
+
+| member      | failed | checks | passed | score | reported    |
+| :---------- | -----: | -----: | -----: | ----: | :---------- |
+| `circle`    |      2 |      2 |      0 |     2 | ✅ (errors) |
+| `square`    |      2 |      2 |      0 |     2 | ✅ (named)  |
+| `rectangle` |      3 |      3 |      0 |     3 |             |
+
+```text
+Error: the value did not match any of the 3 members of the union; the closest member types are <{ kind: "circle", radius: number }>, <{ kind: "square", size: number }>; the first of them failed as follows:
+Error at kind: missing required key "kind".
+Error at radius: missing required key "radius".
+```
+
+`circle` and `square` are equal on both keys, so both are named rather than one being picked silently. If the names the clause adds would themselves pass `UNION_MEMBER_LISTING_MAX_LENGTH`, they are replaced by their count (`3 members are equally close; <…> failed as follows:`) — the same bound that made the union stop listing its members in the first place, applied to the names this clause adds.
+
+### Why this scoring
+
+Five candidate metrics were run against the scenarios above. _errors_ is the member's error count, _checks_ its `checkCountOf`, and _passed_ is `checks - errors`.
+
+| metric                         | 1 discriminated | 2 small unrelated | 3 large near-match | 4 value means neither | 5 empty value |
+| :----------------------------- | :-------------- | :---------------- | :----------------- | :-------------------- | :------------ |
+| `errors` (the original)        | ✅              | ❌ `note`         | ❌ `label`         | ✅                    | ✅            |
+| `errors / checks`              | ✅              | ✅                | ✅                 | ❌ `account`          | 3-way tie     |
+| `-passed`                      | ✅              | ✅                | ✅                 | ❌ `account`          | 3-way tie     |
+| **`errors - passed`** (chosen) | ✅              | ✅ (tie-break)    | ✅                 | ✅                    | ✅            |
+| `errors - 1.5 × passed`        | ✅              | ✅                | ✅                 | ✅                    | ✅            |
+
+- **Error count alone** penalizes a member for being large: every key it declares is another chance to report an error, so a one-key member that the value ignores entirely outranks the member the value was actually trying to be (scenarios 2 and 3).
+- **A ratio** (and the equivalent _maximize passed_) fixes that by throwing away scale, and then loses scenario 4: a mostly-wrong big member wins on percentage and the message becomes a wall of errors. It also flattens scenario 5 into a three-way tie, because _everything failed_ is `1.0` regardless of size.
+- **Subtraction** keeps both terms in absolute units: a member is credited once per check the value satisfied and debited once per check it failed. It is the only unweighted rule that gets every scenario right, and its one tie (scenario 2) is broken by the more specific question — which member recognized more of the value.
+- **Weighting the credit** (`1.5×`) also passes, but the constant is not derived from anything and would need re-tuning against every new scenario, so it was not chosen.
+
+### Known limits
+
+- `checkCountOf` is only meaningful for records and tuples. Everything else counts as one check, so within a category of primitives the scoring degrades to plain error counting — which is the right answer there, since those members have nothing partial to satisfy.
+- A record whose shape cannot be flattened to one set of keys (a union of shapes reached through `recursion`) also counts as one check, and is therefore scored as if it were a primitive.
+- A record that rejects excess properties can report more errors than it has keys; `passed` is clamped at zero rather than going negative.
+- Scoring validates every candidate. This only happens on the failure path, after the value has already been rejected by every member.
+
+### Appendix — why nested unions are flattened
+
+A union taken directly as a member of another union contributes its own members instead of itself:
+
+```ts
+const tagOrCode = union([literal('alpha'), literal(42)]);
+const shape = union([tagOrCode, circle, square]);
+// members: literal('alpha'), literal(42), circle, square
+```
+
+`A | (B | C)` and `A | B | C` describe the same set of values, so this changes nothing about what the union accepts. It matters for step 1 of the selection: a member is filed under _one_ runtime type category, taken from its default value, and a nested union has only one default value. Unflattened, `tagOrCode` would be filed under `string` (its default is `'alpha'`), so validating `41` would leave no candidate at all and the union would fall back to reporting its categories. Flattened, the `42` member is a candidate in its own right:
+
+```text
+Error: the value did not match any of the 4 members of the union; the closest member type is <42>, which failed as follows:
+Error: expected <42> type but <number> type value `41` was passed.
+```
+
+Two deliberate exceptions:
+
+- **`typeName` and the member listing keep the members as they were written.** Flattening those would discard a name the caller chose: `union([Status, nullType])` should still say `expected one of <Status>, <null>` rather than expanding `Status` into its literals. Only the member list used for validation, pruning and error reporting is flattened.
+- **A `recursion` member is never expanded.** Flattening asks each member whether it is a union; the proxy a recursive type returns answers that from the properties it already has, without running its definition. A type defined in terms of itself therefore stays a single opaque member, and building the union does not force its definition.
+
+---
+
+Implementation: `src/compose/union.mts` · Tests: `src/compose/union-closest-member.test.mts`, `src/compose/union-nested-union.test.mts` · Message formats: `src/utils/validation-error.mts`

--- a/packages/ts-fortress/src/brand/branded-string.test.mts
+++ b/packages/ts-fortress/src/brand/branded-string.test.mts
@@ -173,7 +173,7 @@ describe('simpleBrandedString', () => {
         ]);
 
         assert.deepStrictEqual(validationErrorsToMessages(resultError1), [
-          'Error: expected <string> type but <object> type value `null` was passed.',
+          'Error: expected <string> type but <null> type value `null` was passed.',
         ]);
       });
     });

--- a/packages/ts-fortress/src/compose/union-closest-member.test.mts
+++ b/packages/ts-fortress/src/compose/union-closest-member.test.mts
@@ -1,0 +1,328 @@
+import { Result } from 'ts-data-forge';
+import { literal } from '../other-types/index.mjs';
+import { number, string } from '../primitives/index.mjs';
+import { record } from '../record/index.mjs';
+import { type AnyType } from '../type.mjs';
+import { validationErrorsToMessages } from '../utils/index.mjs';
+import { union } from './union.mjs';
+
+/**
+ * When a union's member listing is too long to print, the error reports a
+ * single member instead. That member is chosen in two steps:
+ *
+ * 1. keep the members whose runtime type category (taken from their default
+ *    value) matches the value's,
+ * 2. among those, take the one with the lowest score, where a member scores
+ *    the number of checks it failed minus the number it passed. Members with
+ *    the same score are ordered by how much they satisfied, and members equal
+ *    on both are all named, with the first in declaration order reporting its
+ *    errors.
+ *
+ * `documents/union-closest-member-heuristic.md` records the scenarios the
+ * scoring was chosen against. Each test below first lists what every member
+ * reports on its own, so the counts the choice is made from are visible, and
+ * then checks which member the union ends up blaming.
+ */
+
+/** What a single member reports for `value`, as it would be shown to a user. */
+const memberReport = (
+  memberType: AnyType,
+  value: unknown,
+): Readonly<{ typeName: string; errors: readonly string[] }> => {
+  const result = memberType.validate(value);
+
+  return {
+    typeName: memberType.typeName,
+    errors: Result.isErr(result)
+      ? validationErrorsToMessages(result.value)
+      : [],
+  };
+};
+
+describe('union - closest member selection', () => {
+  const circle = record({ kind: literal('circle'), radius: number() });
+
+  const square = record({ kind: literal('square'), size: number() });
+
+  const rectangle = record({
+    kind: literal('rectangle'),
+    width: number(),
+    height: number(),
+  });
+
+  const shape = union([circle, square, rectangle]);
+
+  describe('one field of one variant is wrong', () => {
+    const value = { kind: 'circle', radius: '5' } as const;
+
+    test('the members report 1 / 2 / 3 errors', () => {
+      assert.deepStrictEqual(
+        [circle, square, rectangle].map((m) => memberReport(m, value)),
+        [
+          {
+            typeName: '{ kind: "circle", radius: number }',
+            errors: [
+              'Error at radius: expected <number> type but <string> type value "5" was passed.',
+            ],
+          },
+          {
+            typeName: '{ kind: "square", size: number }',
+            errors: [
+              'Error at kind: expected <"square"> type but <string> type value "circle" was passed.',
+              'Error at size: missing required key "size".',
+            ],
+          },
+          {
+            typeName: '{ kind: "rectangle", width: number, height: number }',
+            errors: [
+              'Error at kind: expected <"rectangle"> type but <string> type value "circle" was passed.',
+              'Error at width: missing required key "width".',
+              'Error at height: missing required key "height".',
+            ],
+          },
+        ],
+      );
+    });
+
+    test('the union blames the 1-error member', () => {
+      const result = shape.validate(value);
+
+      assert.isTrue(Result.isErr(result));
+
+      assert.deepStrictEqual(
+        validationErrorsToMessages(Result.unwrapErrThrow(result)),
+        [
+          'Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle", radius: number }>, which failed as follows:',
+          'Error at radius: expected <number> type but <string> type value "5" was passed.',
+        ],
+      );
+    });
+  });
+
+  describe('the discriminant names no variant', () => {
+    // Every variant fails on `kind`, so what separates them is how much of
+    // the rest of the value they accept: `radius: 5` satisfies the circle.
+    const value = { kind: 'triangle', radius: 5 } as const;
+
+    test('the members report 1 / 2 / 3 errors', () => {
+      assert.deepStrictEqual(
+        [circle, square, rectangle].map((m) => memberReport(m, value).errors),
+        [
+          [
+            'Error at kind: expected <"circle"> type but <string> type value "triangle" was passed.',
+          ],
+          [
+            'Error at kind: expected <"square"> type but <string> type value "triangle" was passed.',
+            'Error at size: missing required key "size".',
+          ],
+          [
+            'Error at kind: expected <"rectangle"> type but <string> type value "triangle" was passed.',
+            'Error at width: missing required key "width".',
+            'Error at height: missing required key "height".',
+          ],
+        ],
+      );
+    });
+
+    test('the union blames the variant whose other fields are satisfied', () => {
+      const result = shape.validate(value);
+
+      assert.isTrue(Result.isErr(result));
+
+      assert.deepStrictEqual(
+        validationErrorsToMessages(Result.unwrapErrThrow(result)),
+        [
+          'Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle", radius: number }>, which failed as follows:',
+          'Error at kind: expected <"circle"> type but <string> type value "triangle" was passed.',
+        ],
+      );
+    });
+  });
+
+  describe('nothing in the value points at a variant', () => {
+    const value = {} as const;
+
+    test('the two smallest members tie at 2 errors', () => {
+      assert.deepStrictEqual(
+        [circle, square, rectangle].map((m) => memberReport(m, value).errors),
+        [
+          [
+            'Error at kind: missing required key "kind".',
+            'Error at radius: missing required key "radius".',
+          ],
+          [
+            'Error at kind: missing required key "kind".',
+            'Error at size: missing required key "size".',
+          ],
+          [
+            'Error at kind: missing required key "kind".',
+            'Error at width: missing required key "width".',
+            'Error at height: missing required key "height".',
+          ],
+        ],
+      );
+    });
+
+    test('both tied members are named, and the first reports its errors', () => {
+      assert.deepStrictEqual(
+        validationErrorsToMessages(
+          Result.unwrapErrThrow(shape.validate(value)),
+        ),
+        [
+          'Error: the value did not match any of the 3 members of the union; the closest member types are <{ kind: "circle", radius: number }>, <{ kind: "square", size: number }>; the first of them failed as follows:',
+          'Error at kind: missing required key "kind".',
+          'Error at radius: missing required key "radius".',
+        ],
+      );
+    });
+
+    test('the errors shown are the first tied member in declaration order', () => {
+      // Reordering the members moves the reported errors to the other tied
+      // member, as it does for `prune` and `fill`.
+      assert.deepStrictEqual(
+        validationErrorsToMessages(
+          Result.unwrapErrThrow(
+            union([square, circle, rectangle]).validate(value),
+          ),
+        ),
+        [
+          'Error: the value did not match any of the 3 members of the union; the closest member types are <{ kind: "square", size: number }>, <{ kind: "circle", radius: number }>; the first of them failed as follows:',
+          'Error at kind: missing required key "kind".',
+          'Error at size: missing required key "size".',
+        ],
+      );
+    });
+  });
+
+  describe('too many members tie to name them all', () => {
+    // Naming the tied members follows the same length bound as the member
+    // listing itself: once the names it would add grow past it, they are
+    // replaced by their count.
+    const alpha = record({ alpha: string(), alphaCount: number() });
+
+    const bravo = record({ bravo: string(), bravoCount: number() });
+
+    const charlie = record({ charlie: string(), charlieCount: number() });
+
+    test('the tied members are replaced by their count', () => {
+      assert.deepStrictEqual(
+        validationErrorsToMessages(
+          Result.unwrapErrThrow(union([alpha, bravo, charlie]).validate({})),
+        ),
+        [
+          'Error: the value did not match any of the 3 members of the union; 3 members are equally close; <{ alpha: string, alphaCount: number }> failed as follows:',
+          'Error at alpha: missing required key "alpha".',
+          'Error at alphaCount: missing required key "alphaCount".',
+        ],
+      );
+    });
+  });
+
+  describe('the value belongs to no member category', () => {
+    // The category filter runs before any error counting, so members that
+    // cannot describe this kind of value never compete on error count.
+    test('a number against a union of records', () => {
+      const result = shape.validate(42);
+
+      assert.isTrue(Result.isErr(result));
+
+      assert.deepStrictEqual(
+        validationErrorsToMessages(Result.unwrapErrThrow(result)),
+        [
+          'Error: the value did not match any of the 3 members of the union; expected a value of type <object> but <number> type value `42` was passed.',
+        ],
+      );
+    });
+  });
+
+  describe('a small unrelated member does not outrank a near-match', () => {
+    // Counting errors alone would report `note` here: it fails a single check
+    // while `config` fails two. Crediting the checks a member passed puts them
+    // level (config 2 - 1 = 1, note 1 - 0 = 1) and the tie then goes to the
+    // member that recognized more of the value.
+    const config = record({
+      kind: literal('config'),
+      host: string(),
+      port: number(),
+    });
+
+    const note = record({ note: string() });
+
+    const value = { kind: 'config', host: 5, port: 'not a number' } as const;
+
+    test('the near-match reports more errors than the unrelated member', () => {
+      assert.deepStrictEqual(
+        [config, note].map((m) => memberReport(m, value).errors),
+        [
+          [
+            'Error at host: expected <string> type but <number> type value `5` was passed.',
+            'Error at port: expected <number> type but <string> type value "not a number" was passed.',
+          ],
+          ['Error at note: missing required key "note".'],
+        ],
+      );
+    });
+
+    test('the member that satisfied a check is still the one reported', () => {
+      assert.deepStrictEqual(
+        validationErrorsToMessages(
+          Result.unwrapErrThrow(union([config, note]).validate(value)),
+        ),
+        [
+          'Error: the value did not match any of the 2 members of the union; the closest member type is <{ kind: "config", host: string, port: number }>, which failed as follows:',
+          'Error at host: expected <string> type but <number> type value `5` was passed.',
+          'Error at port: expected <number> type but <string> type value "not a number" was passed.',
+        ],
+      );
+    });
+  });
+
+  describe('a large member the value mostly satisfies wins on score', () => {
+    // account fails 2 of its 5 checks and passes 3, scoring -1; label fails its
+    // single check and passes none, scoring 1. Error counts alone would have
+    // reported `label` and its one unhelpful error.
+    const account = record({
+      id: number(),
+      name: string(),
+      email: string(),
+      role: string(),
+      age: number(),
+    });
+
+    const label = record({ label: string() });
+
+    const value = {
+      id: 1,
+      name: 'Ada',
+      email: 'ada@example.com',
+      role: 7,
+      age: 'unknown',
+    } as const;
+
+    test('the members report 2 / 1 errors', () => {
+      assert.deepStrictEqual(
+        [account, label].map((m) => memberReport(m, value).errors),
+        [
+          [
+            'Error at role: expected <string> type but <number> type value `7` was passed.',
+            'Error at age: expected <number> type but <string> type value "unknown" was passed.',
+          ],
+          ['Error at label: missing required key "label".'],
+        ],
+      );
+    });
+
+    test('the member with more errors but a better score is reported', () => {
+      assert.deepStrictEqual(
+        validationErrorsToMessages(
+          Result.unwrapErrThrow(union([account, label]).validate(value)),
+        ),
+        [
+          'Error: the value did not match any of the 2 members of the union; the closest member type is <{ id: number, name: string, email: string, role: string, age: number }>, which failed as follows:',
+          'Error at role: expected <string> type but <number> type value `7` was passed.',
+          'Error at age: expected <number> type but <string> type value "unknown" was passed.',
+        ],
+      );
+    });
+  });
+});

--- a/packages/ts-fortress/src/compose/union-error-message.test.mts
+++ b/packages/ts-fortress/src/compose/union-error-message.test.mts
@@ -1,0 +1,173 @@
+import { Result } from 'ts-data-forge';
+import { literal } from '../other-types/index.mjs';
+import { number } from '../primitives/index.mjs';
+import { record } from '../record/index.mjs';
+import { validationErrorsToMessages } from '../utils/index.mjs';
+import { union } from './union.mjs';
+
+// These tests pin down the error messages produced when a value fails to
+// match a union type, especially for unions whose member listing is long.
+
+describe('union - error messages', () => {
+  // A discriminated union whose full member listing is too long to be a
+  // readable error message.
+  const circle = record({ kind: literal('circle'), radius: number() });
+
+  const square = record({ kind: literal('square'), size: number() });
+
+  const rectangle = record({
+    kind: literal('rectangle'),
+    width: number(),
+    height: number(),
+  });
+
+  const shape = union([circle, square, rectangle]);
+
+  describe('long union', () => {
+    test('value that almost matches one member (wrong value type for one key)', () => {
+      const result = shape.validate({ kind: 'circle', radius: '5' });
+
+      assert.isTrue(Result.isErr(result));
+
+      const resultError = Result.unwrapErrThrow(result);
+
+      assert.deepStrictEqual(validationErrorsToMessages(resultError), [
+        'Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle", radius: number }>, which failed as follows:',
+        'Error at radius: expected <number> type but <string> type value "5" was passed.',
+      ]);
+    });
+
+    test('the discriminant key determines the member reported in the error', () => {
+      const result = shape.validate({ kind: 'square', size: 'big' });
+
+      assert.isTrue(Result.isErr(result));
+
+      const resultError = Result.unwrapErrThrow(result);
+
+      assert.deepStrictEqual(validationErrorsToMessages(resultError), [
+        'Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "square", size: number }>, which failed as follows:',
+        'Error at size: expected <number> type but <string> type value "big" was passed.',
+      ]);
+    });
+
+    test('value whose typeof matches no member', () => {
+      const result = shape.validate(42);
+
+      assert.isTrue(Result.isErr(result));
+
+      const resultError = Result.unwrapErrThrow(result);
+
+      assert.deepStrictEqual(resultError[0], {
+        path: [],
+        actualValue: 42,
+        expectedType:
+          '({ kind: "circle", radius: number } | { kind: "square", size: number } | { kind: "rectangle", width: number, height: number })',
+        typeName:
+          '({ kind: "circle", radius: number } | { kind: "square", size: number } | { kind: "rectangle", width: number, height: number })',
+        details: {
+          kind: 'union-category-mismatch',
+          memberCount: 3,
+          memberCategories: ['object'],
+        },
+      });
+
+      assert.deepStrictEqual(validationErrorsToMessages(resultError), [
+        'Error: the value did not match any of the 3 members of the union; expected a value of type <object> but <number> type value `42` was passed.',
+      ]);
+    });
+
+    test('union nested in a record keeps the path prefix', () => {
+      const holder = record({ shape });
+
+      const result = holder.validate({
+        shape: { kind: 'circle', radius: '5' },
+      });
+
+      assert.isTrue(Result.isErr(result));
+
+      const resultError = Result.unwrapErrThrow(result);
+
+      assert.deepStrictEqual(validationErrorsToMessages(resultError), [
+        'Error at shape: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle", radius: number }>, which failed as follows:',
+        'Error at shape.radius: expected <number> type but <string> type value "5" was passed.',
+      ]);
+    });
+  });
+
+  describe('short union', () => {
+    // A union whose member listing is short enough to be readable as-is.
+    const color = union([literal('red'), literal('green'), literal('blue')]);
+
+    test('all members are listed in the error message', () => {
+      const result = color.validate('purple');
+
+      assert.isTrue(Result.isErr(result));
+
+      const resultError = Result.unwrapErrThrow(result);
+
+      assert.deepStrictEqual(resultError[0], {
+        path: [],
+        actualValue: 'purple',
+        expectedType: '("red" | "green" | "blue")',
+        typeName: '("red" | "green" | "blue")',
+        details: {
+          kind: 'union',
+          typeNames: ['"red"', '"green"', '"blue"'],
+        },
+      });
+
+      assert.deepStrictEqual(validationErrorsToMessages(resultError), [
+        'Error: expected one of <"red">, <"green">, <"blue"> but <string> type value "purple" was passed.',
+      ]);
+    });
+
+    test('a value too long to print is reported as matching no member', () => {
+      // Printing the value is what tells the reader why it was rejected, so
+      // when it has to be omitted the message says so instead of reporting
+      // only its runtime type (which is a type the union does accept).
+      const result = color.validate('purple'.repeat(10));
+
+      assert.isTrue(Result.isErr(result));
+
+      assert.deepStrictEqual(
+        validationErrorsToMessages(Result.unwrapErrThrow(result)),
+        [
+          'Error: expected one of <"red">, <"green">, <"blue"> but a string of length 60 matching none of them was passed.',
+        ],
+      );
+    });
+  });
+
+  describe('basic containers are named in place of a bare object', () => {
+    test('an array passed to a union of records', () => {
+      const result = shape.validate([1, 2, 3]);
+
+      assert.isTrue(Result.isErr(result));
+
+      const resultError = Result.unwrapErrThrow(result);
+
+      assert.deepStrictEqual(resultError[0]?.details, {
+        kind: 'union-category-mismatch',
+        memberCount: 3,
+        memberCategories: ['object'],
+      });
+
+      assert.deepStrictEqual(validationErrorsToMessages(resultError), [
+        'Error: the value did not match any of the 3 members of the union; expected a value of type <object> but <array> type value `[1,2,3]` was passed.',
+      ]);
+    });
+
+    test('a Map passed to a union of records', () => {
+      const result = shape.validate(new Map([['radius', 5]]));
+
+      assert.isTrue(Result.isErr(result));
+
+      assert.deepStrictEqual(
+        validationErrorsToMessages(Result.unwrapErrThrow(result)),
+        [
+          'Error: the value did not match any of the 3 members of the union; expected a value of type <object> but <Map> type value `Map([["radius",5]])` was passed.',
+        ],
+      );
+    });
+  });
+});

--- a/packages/ts-fortress/src/compose/union-mixed.test.mts
+++ b/packages/ts-fortress/src/compose/union-mixed.test.mts
@@ -158,7 +158,7 @@ describe('union - mixed types', () => {
       });
 
       assert.deepStrictEqual(validationErrorsToMessages(resultError), [
-        'Error: expected one of <"empty">, <number>, <{ status: string }>, <number[]> but <object> type value `null` was passed.',
+        'Error: expected one of <"empty">, <number>, <{ status: string }>, <number[]> but <null> type value `null` was passed.',
       ]);
     });
 

--- a/packages/ts-fortress/src/compose/union-nested-record.test.mts
+++ b/packages/ts-fortress/src/compose/union-nested-record.test.mts
@@ -133,16 +133,19 @@ describe('union - nested records', () => {
         typeName:
           '({ type: string, data: { value: number } } | { kind: string, config: { enabled: string } })',
         details: {
-          kind: 'union',
-          typeNames: [
-            '{ type: string, data: { value: number } }',
+          kind: 'union-closest-member',
+          memberCount: 2,
+          closestMemberTypeName: '{ type: string, data: { value: number } }',
+          equallyCloseMemberTypeNames: [
             '{ kind: string, config: { enabled: string } }',
           ],
         },
       });
 
       assert.deepStrictEqual(validationErrorsToMessages(resultError), [
-        'Error: expected one of <{ type: string, data: { value: number } }>, <{ kind: string, config: { enabled: string } }> but <object> type value `{"invalid":"data"}` was passed.',
+        'Error: the value did not match any of the 2 members of the union; the closest member types are <{ type: string, data: { value: number } }>, <{ kind: string, config: { enabled: string } }>; the first of them failed as follows:',
+        'Error at type: missing required key "type".',
+        'Error at data: missing required key "data".',
       ]);
     });
 

--- a/packages/ts-fortress/src/compose/union-nested-union.test.mts
+++ b/packages/ts-fortress/src/compose/union-nested-union.test.mts
@@ -1,0 +1,131 @@
+import { Result } from 'ts-data-forge';
+import { literal, recursion } from '../other-types/index.mjs';
+import { nullType, number, string } from '../primitives/index.mjs';
+import { record } from '../record/index.mjs';
+import { type Type } from '../type.mjs';
+import { validationErrorsToMessages } from '../utils/index.mjs';
+import { union } from './union.mjs';
+
+/**
+ * `A | (B | C)` and `A | B | C` describe the same set of values, so a union
+ * nested directly inside another union is flattened into it. The members are
+ * what the error path reasons about — a nested union would otherwise be
+ * summarized by the single runtime type category of its default value.
+ */
+
+describe('union - nested unions', () => {
+  const circle = record({ kind: literal('circle'), radius: number() });
+
+  const square = record({ kind: literal('square'), size: number() });
+
+  // Nested union whose members are of two different runtime type categories.
+  const tagOrCode = union([literal('alpha'), literal(42)]);
+
+  const nested = union([tagOrCode, circle, square]);
+
+  test('a value matching an inner member is accepted', () => {
+    assert.isTrue(nested.is('alpha'));
+
+    assert.isTrue(nested.is(42));
+
+    assert.isTrue(nested.is({ kind: 'circle', radius: 1 }));
+  });
+
+  test('an inner member can be reported as the closest one', () => {
+    // Only `42` shares the value's runtime type category. Without flattening,
+    // the nested union would be filed under the category of its default value
+    // (`"alpha"`, a string) and no member would be left to blame.
+    const result = nested.validate(41);
+
+    assert.isTrue(Result.isErr(result));
+
+    assert.deepStrictEqual(
+      validationErrorsToMessages(Result.unwrapErrThrow(result)),
+      [
+        'Error: the value did not match any of the 4 members of the union; the closest member type is <42>, which failed as follows:',
+        'Error: expected <42> type but <number> type value `41` was passed.',
+      ],
+    );
+  });
+
+  test('the flattened members are counted, not the members as written', () => {
+    // 3 members as written, 4 after the nested union is flattened in.
+    const result = nested.validate(true);
+
+    assert.isTrue(Result.isErr(result));
+
+    assert.deepStrictEqual(
+      validationErrorsToMessages(Result.unwrapErrThrow(result)),
+      [
+        'Error: the value did not match any of the 4 members of the union; expected a value of type <string> | <number> | <object> but <boolean> type value `true` was passed.',
+      ],
+    );
+  });
+
+  test('the type name keeps the members as they were written', () => {
+    expect(nested.typeName).toBe(
+      '(("alpha" | 42) | { kind: "circle", radius: number } | { kind: "square", size: number })',
+    );
+  });
+
+  test('a nested union with a name of its own keeps it in the member listing', () => {
+    // Short enough to list every member, so the name the caller chose is what
+    // the message shows.
+    const status = union([literal('active'), literal('done')], {
+      typeName: 'Status',
+    });
+
+    const result = union([status, nullType]).validate('unknown');
+
+    assert.isTrue(Result.isErr(result));
+
+    assert.deepStrictEqual(
+      validationErrorsToMessages(Result.unwrapErrThrow(result)),
+      [
+        'Error: expected one of <Status>, <null> but <string> type value "unknown" was passed.',
+      ],
+    );
+  });
+
+  describe('a recursive member stays opaque', () => {
+    // Flattening asks each member whether it is a union. A `recursion` type
+    // answers that without running its definition, so a type defined in terms
+    // of itself is taken as a single member instead of being expanded.
+    const makeTree = (onDefinition: () => void): Type<unknown> =>
+      recursion('Tree', () => {
+        onDefinition();
+
+        return union([
+          nullType,
+          record({ value: number(), children: string() }),
+        ]);
+      });
+
+    test('building the union does not run the definition', () => {
+      let mut_definitionCalls = 0;
+
+      const tree = makeTree(() => {
+        mut_definitionCalls += 1;
+      });
+
+      union([string(), tree]);
+
+      expect(mut_definitionCalls).toBe(0);
+    });
+
+    test('the recursive member is listed as itself, not as its members', () => {
+      const treeOrLabel = union([string(), makeTree(() => {})]);
+
+      const result = treeOrLabel.validate(42);
+
+      assert.isTrue(Result.isErr(result));
+
+      assert.deepStrictEqual(
+        validationErrorsToMessages(Result.unwrapErrThrow(result)),
+        [
+          'Error: expected one of <string>, <Tree> but <number> type value `42` was passed.',
+        ],
+      );
+    });
+  });
+});

--- a/packages/ts-fortress/src/compose/union-primitive-literal.test.mts
+++ b/packages/ts-fortress/src/compose/union-primitive-literal.test.mts
@@ -123,7 +123,7 @@ describe('union - primitive and literal', () => {
       });
 
       assert.deepStrictEqual(validationErrorsToMessages(resultError), [
-        'Error: expected one of <string>, <42>, <number> but <object> type value `null` was passed.',
+        'Error: expected one of <string>, <42>, <number> but <null> type value `null` was passed.',
       ]);
     });
 

--- a/packages/ts-fortress/src/compose/union-records.test.mts
+++ b/packages/ts-fortress/src/compose/union-records.test.mts
@@ -116,16 +116,17 @@ describe('union - records only', () => {
         typeName:
           '({ kind: string, value: number } | { type: string, data: string })',
         details: {
-          kind: 'union',
-          typeNames: [
-            '{ kind: string, value: number }',
-            '{ type: string, data: string }',
-          ],
+          kind: 'union-closest-member',
+          memberCount: 2,
+          closestMemberTypeName: '{ kind: string, value: number }',
+          equallyCloseMemberTypeNames: ['{ type: string, data: string }'],
         },
       });
 
       assert.deepStrictEqual(validationErrorsToMessages(resultError), [
-        'Error: expected one of <{ kind: string, value: number }>, <{ type: string, data: string }> but <object> type value was passed.',
+        'Error: the value did not match any of the 2 members of the union; the closest member types are <{ kind: string, value: number }>, <{ type: string, data: string }>; the first of them failed as follows:',
+        'Error at kind: missing required key "kind".',
+        'Error at value: missing required key "value".',
       ]);
     });
 

--- a/packages/ts-fortress/src/compose/union.mts
+++ b/packages/ts-fortress/src/compose/union.mts
@@ -1,17 +1,23 @@
-import { Arr, Result, expectType, memoizeFunction } from 'ts-data-forge';
+import { Arr, expectType, memoizeFunction, Result } from 'ts-data-forge';
 import { type ArrayElement, type NonEmptyTuple } from 'ts-type-forge';
 import {
+  flattenShapeStructure,
   hasRecordInternals,
+  hasTupleInternals,
+  hasUnionInternals,
   type AnyType,
   type ExcessPropertyOption,
   type Type,
   type TypeOf,
+  type UnionTypeInternals,
 } from '../type.mjs';
 import {
   createAssertFn,
   createCastFn,
   createIsFn,
+  runtimeTypeNameOf,
   toUnionString,
+  UNION_MEMBER_LISTING_MAX_LENGTH,
   type ValidationError,
 } from '../utils/index.mjs';
 
@@ -34,22 +40,113 @@ export const union = <const Types extends NonEmptyTuple<AnyType>>(
   const typeNameFilled: string =
     options?.typeName ?? `(${toUnionString(types.map((a) => a.typeName))})`;
 
-  const validate: Type<T>['validate'] = (a) =>
-    types.some((t) => t.is(a))
-      ? // eslint-disable-next-line total-functions/no-unsafe-type-assertion
-        Result.ok(a as T)
-      : Result.err([
-          {
-            path: [],
-            actualValue: a,
-            expectedType: typeNameFilled,
-            typeName: typeNameFilled,
-            details: {
-              kind: 'union',
-              typeNames: types.map((t) => t.typeName),
-            },
-          } satisfies ValidationError,
-        ]);
+  /**
+   * A union nested directly inside this one contributes its own members
+   * instead of itself. `A | (B | C)` and `A | B | C` describe the same set of
+   * values, so this changes nothing about what the union accepts.
+   *
+   * It was introduced for the error path. Reporting the member closest to a
+   * rejected value starts by filing each member under a single runtime type
+   * category, taken from its default value — and a nested union has only one
+   * default value. Unflattened, `union([union([literal('alpha'), literal(42)]),
+   * ...])` is filed under `string`, so validating `41` finds no candidate at
+   * all and the union falls back to listing the categories it accepts.
+   * Flattened, the `42` member competes on its own and is reported.
+   *
+   * Two things deliberately stay unflattened: `typeName` and the member
+   * listing use the members as they were written, so a nested union that
+   * carries a name of its own keeps it; and a `recursion` member answers
+   * {@link hasUnionInternals} without running its definition, so a type
+   * defined in terms of itself stays a single opaque member.
+   *
+   * See `documents/union-closest-member-heuristic.md`.
+   */
+  const memberTypes: readonly AnyType[] = types.flatMap((t) =>
+    hasUnionInternals(t) ? t.memberTypes : [t],
+  );
+
+  const validate: Type<T>['validate'] = (a) => {
+    if (memberTypes.some((t) => t.is(a))) {
+      // eslint-disable-next-line total-functions/no-unsafe-type-assertion
+      return Result.ok(a as T);
+    }
+
+    const memberTypeNames = types.map((t) => t.typeName);
+
+    if (
+      toUnionString(memberTypeNames).length <= UNION_MEMBER_LISTING_MAX_LENGTH
+    ) {
+      return Result.err([
+        {
+          path: [],
+          actualValue: a,
+          expectedType: typeNameFilled,
+          typeName: typeNameFilled,
+          details: {
+            kind: 'union',
+            typeNames: memberTypeNames,
+          },
+        } satisfies ValidationError,
+      ]);
+    }
+
+    // The member listing is too long to be a readable error message, so
+    // narrow the report down to the members whose runtime type category
+    // (derived from each member's default value) matches the value.
+    const actualCategory = runtimeTypeNameOf(a);
+
+    const candidates = memberTypes
+      .filter((t) => runtimeTypeNameOf(t.defaultValue) === actualCategory)
+      .map((t) => evaluateMember(t, a));
+
+    if (!Arr.isNonEmpty(candidates)) {
+      return Result.err([
+        {
+          path: [],
+          actualValue: a,
+          expectedType: typeNameFilled,
+          typeName: typeNameFilled,
+          details: {
+            kind: 'union-category-mismatch',
+            memberCount: memberTypes.length,
+            memberCategories: Arr.uniq(
+              memberTypes.map((t) => runtimeTypeNameOf(t.defaultValue)),
+            ),
+          },
+        } satisfies ValidationError,
+      ]);
+    }
+
+    // The closest member is the one with the lowest similarity score (see
+    // `evaluateMember`); its errors explain the mismatch far better than the
+    // full member listing would. Members that tie with it are named alongside
+    // it, and the first of them (in declaration order, as in `prune` and
+    // `fill`) is the one whose errors are reported.
+    const closest = Arr.minBy(
+      candidates,
+      (candidate) => candidate,
+      compareByCloseness,
+    ).value;
+
+    const equallyClose = candidates.filter(
+      (c) => c !== closest && compareByCloseness(c, closest) === 0,
+    );
+
+    return Result.err(
+      Arr.toUnshifted({
+        path: [],
+        actualValue: a,
+        expectedType: typeNameFilled,
+        typeName: typeNameFilled,
+        details: {
+          kind: 'union-closest-member',
+          memberCount: memberTypes.length,
+          closestMemberTypeName: closest.typeName,
+          equallyCloseMemberTypeNames: equallyClose.map((c) => c.typeName),
+        },
+      } satisfies ValidationError)(closest.errors),
+    );
+  };
 
   const is = createIsFn<T>(validate);
 
@@ -57,7 +154,7 @@ export const union = <const Types extends NonEmptyTuple<AnyType>>(
 
   // Prunes with the first member type that matches the value.
   const prune = (a: T): T => {
-    const matched = types.find((t) => t.is(a));
+    const matched = memberTypes.find((t) => t.is(a));
 
     return matched === undefined
       ? a
@@ -65,7 +162,7 @@ export const union = <const Types extends NonEmptyTuple<AnyType>>(
         (matched.prune(a) as T);
   };
 
-  const baseType: Type<T> = {
+  const baseType = {
     typeName: typeNameFilled,
     get defaultValue() {
       return getDefaultType().defaultValue;
@@ -76,7 +173,9 @@ export const union = <const Types extends NonEmptyTuple<AnyType>>(
     is,
     assertIs: createAssertFn(validate),
     cast: createCastFn(validate),
-  } as const;
+    // Lets a union that takes this one as a member flatten it in.
+    memberTypes,
+  } as const satisfies Type<T> & UnionTypeInternals;
 
   // If all types are records, add RecordTypeInternals with union structure
   if (types.every(hasRecordInternals)) {
@@ -99,8 +198,80 @@ export const union = <const Types extends NonEmptyTuple<AnyType>>(
     } as UnionType<Types>;
   }
 
-  return baseType;
+  return baseType as UnionType<Types>;
 };
+
+/**
+ * How close a member is to a value it rejected.
+ *
+ * `score` is the number of checks the member failed minus the number it
+ * passed, so a member is credited for what the value does satisfy. Plain error
+ * counting would let a small unrelated member (one missing key) outrank a large
+ * member the value nearly satisfies (two wrong fields out of ten), while a
+ * ratio would do the opposite and let a large member win with a long list of
+ * errors just because it also has many keys. Subtracting keeps both the failed
+ * and the passed checks in absolute terms.
+ *
+ * Members with the same score are ordered by how much they satisfied, so the
+ * one that recognized more of the value comes first.
+ *
+ * See `documents/union-closest-member-heuristic.md` for the scenarios these
+ * rules were chosen against.
+ */
+type MemberCloseness = Readonly<{
+  typeName: string;
+  errors: readonly ValidationError[];
+  satisfiedCheckCount: number;
+  score: number;
+}>;
+
+const evaluateMember = (memberType: AnyType, a: unknown): MemberCloseness => {
+  const errors = validationErrorsOf(memberType.validate(a));
+
+  // A member cannot pass fewer than zero checks: a record that rejects excess
+  // properties can report more errors than it has keys.
+  const satisfiedCheckCount = Math.max(
+    0,
+    checkCountOf(memberType) - errors.length,
+  );
+
+  return {
+    typeName: memberType.typeName,
+    errors,
+    satisfiedCheckCount,
+    score: errors.length - satisfiedCheckCount,
+  };
+};
+
+const compareByCloseness = (x: MemberCloseness, y: MemberCloseness): number =>
+  x.score !== y.score
+    ? x.score - y.score
+    : y.satisfiedCheckCount - x.satisfiedCheckCount;
+
+/**
+ * How many checks a member performs on a value: one per key for a record, one
+ * per element for a tuple, and a single check for everything else, which either
+ * matches or does not. A record whose shape cannot be flattened to a single set
+ * of keys (a union of shapes) also counts as one check.
+ */
+const checkCountOf = (memberType: AnyType): number => {
+  if (hasRecordInternals(memberType)) {
+    const shape = flattenShapeStructure(memberType.shapeStructure);
+
+    return shape === undefined ? 1 : Object.keys(shape).length;
+  }
+
+  if (hasTupleInternals(memberType)) {
+    return memberType.elementTypes.length;
+  }
+
+  return 1;
+};
+
+const validationErrorsOf = (
+  result: Result<unknown, readonly ValidationError[]>,
+): readonly ValidationError[] =>
+  Result.isErr(result) ? result.value : ([] as const);
 
 type UnionType<Types extends NonEmptyTuple<AnyType>> = Type<
   UnionTypeValue<Types>

--- a/packages/ts-fortress/src/other-types/set.test.mts
+++ b/packages/ts-fortress/src/other-types/set.test.mts
@@ -146,7 +146,7 @@ test('SetType cast() method', () => {
   );
 
   expect(() => StringSet.cast([])).toThrow(
-    'Error: expected <Set> type but <object> type value',
+    'Error: expected <Set> type but <array> type value',
   );
 });
 
@@ -171,7 +171,7 @@ test('SetType assertIs() method', () => {
 
   expect(() => {
     assertIsNumberSet([1, 2, 3]);
-  }).toThrow('Error: expected <Set> type but <object> type value');
+  }).toThrow('Error: expected <Set> type but <array> type value');
 });
 
 test('SetType with custom typeName', () => {

--- a/packages/ts-fortress/src/primitives/undefined.test.mts
+++ b/packages/ts-fortress/src/primitives/undefined.test.mts
@@ -67,7 +67,7 @@ describe('undefined type', () => {
       expect(() => {
         undefinedType.assertIs(value);
       }).toThrow(
-        'Error: expected <undefined> type but <object> type value `null` was passed.',
+        'Error: expected <undefined> type but <null> type value `null` was passed.',
       );
     });
   });
@@ -87,7 +87,7 @@ describe('undefined type', () => {
       expect(() => {
         undefinedType.cast(value);
       }).toThrow(
-        'Error: expected <undefined> type but <object> type value `null` was passed.',
+        'Error: expected <undefined> type but <null> type value `null` was passed.',
       );
     });
 

--- a/packages/ts-fortress/src/type.mts
+++ b/packages/ts-fortress/src/type.mts
@@ -115,6 +115,16 @@ export type TupleTypeInternals = Readonly<{
   elementTypes: readonly Type<unknown>[];
 }>;
 
+/**
+ * @internal Internal properties attached to union types so that a union
+ * nested directly inside another union can contribute its own members to the
+ * parent (see {@link hasUnionInternals}).
+ */
+export type UnionTypeInternals = Readonly<{
+  /** The member types, with directly nested unions already flattened in. */
+  memberTypes: readonly AnyType[];
+}>;
+
 /** @internal Helper to flatten ShapeStructure to a simple shape if possible */
 export const flattenShapeStructure = (
   structure: ShapeStructure,
@@ -230,6 +240,20 @@ export const hasTupleInternals = <T extends AnyType>(
 
 const hasTupleInternalsImpl = (t: unknown): t is TupleTypeInternals =>
   isRecord(t) && hasKey(t, 'elementTypes') && Arr.isArray(t.elementTypes);
+
+/**
+ * @internal Runtime check for union type internals.
+ *
+ * A `recursion` type answers this without resolving its definition (its proxy
+ * only forwards the keys the base type already has), so a recursive member is
+ * treated as an opaque type rather than being flattened.
+ */
+export const hasUnionInternals = <T extends AnyType>(
+  t: T,
+): t is T & UnionTypeInternals => hasUnionInternalsImpl(t);
+
+const hasUnionInternalsImpl = (t: unknown): t is UnionTypeInternals =>
+  isRecord(t) && hasKey(t, 'memberTypes') && Arr.isArray(t.memberTypes);
 
 const isValidShapeStructure = (s: unknown): s is ShapeStructure => {
   if (!isRecord(s) || !hasKey(s, 'kind')) return false;

--- a/packages/ts-fortress/src/utils/validation-error.formatting.test.mts
+++ b/packages/ts-fortress/src/utils/validation-error.formatting.test.mts
@@ -1,123 +1,423 @@
-import { validationErrorToMessage } from './validation-error.mjs';
+import {
+  validationErrorToMessage,
+  type ValidationError,
+  type ValidationErrorDetails,
+} from './validation-error.mjs';
 
-describe('validation-error formatting details', () => {
-  test('uses custom message with path suffix', () => {
-    const msg = validationErrorToMessage(
+/**
+ * `validationErrorToMessage` renders the offending value inline only while it
+ * fits in `maxLengthToPrintActualValue`; past that budget the value is
+ * replaced by a description of it. These tests compare both renderings of the
+ * same error side by side so every format that depends on the budget can be
+ * read off a single table.
+ */
+
+/** Budget large enough to print every value used below. */
+const PRINTED = 100;
+
+/** Budget that prints nothing, so every value used below is described instead. */
+const OMITTED = 0;
+
+const errorOf = ({
+  actualValue,
+  expectedType,
+  details,
+}: Readonly<{
+  actualValue: unknown;
+  expectedType: string;
+  details: ValidationErrorDetails | undefined;
+}>): ValidationError =>
+  ({
+    path: [],
+    actualValue,
+    expectedType,
+    typeName: expectedType,
+    details,
+  }) as const;
+
+describe(validationErrorToMessage, () => {
+  describe('how the offending value is rendered', () => {
+    // Only the value rendering varies here, so every row is checked against
+    // the same surrounding message. `typeof` reports a bare `object` for null
+    // and for every container, hence the individual names.
+    test.each([
       {
-        path: ['a', 'b'],
-        actualValue: 123,
-        expectedType: 'number',
-        typeName: 'number',
+        actualValue: 'purple',
+        printed: '<string> type value "purple"',
+        omitted: 'a string of length 6',
+      },
+      {
+        actualValue: 42,
+        printed: '<number> type value `42`',
+        omitted: 'a value of type <number>',
+      },
+      {
+        actualValue: -1n,
+        printed: '<bigint> type value `-1n`',
+        omitted: 'a value of type <bigint>',
+      },
+      {
+        actualValue: true,
+        printed: '<boolean> type value `true`',
+        omitted: 'a value of type <boolean>',
+      },
+      {
+        actualValue: null,
+        printed: '<null> type value `null`',
+        omitted: 'a value of type <null>',
+      },
+      {
+        actualValue: undefined,
+        printed: '<undefined> type value `undefined`',
+        omitted: 'a value of type <undefined>',
+      },
+      {
+        actualValue: { a: 1, b: 2 },
+        printed: '<object> type value `{"a":1,"b":2}`',
+        omitted: 'a value of type <object>',
+      },
+      {
+        actualValue: [1, 2, 3],
+        printed: '<array> type value `[1,2,3]`',
+        omitted: 'an array of length 3',
+      },
+      {
+        actualValue: new Map([['a', 1]]),
+        printed: '<Map> type value `Map([["a",1]])`',
+        omitted: 'a Map of size 1',
+      },
+      {
+        actualValue: new Set([1, 2]),
+        printed: '<Set> type value `Set([1,2])`',
+        omitted: 'a Set of size 2',
+      },
+    ])('$printed / $omitted', ({ actualValue, printed, omitted }) => {
+      const error = errorOf({
+        actualValue,
+        expectedType: 'Target',
+        details: undefined,
+      });
+
+      expect(validationErrorToMessage(error, PRINTED)).toBe(
+        `Error: expected <Target> type but ${printed} was passed.`,
+      );
+
+      expect(validationErrorToMessage(error, OMITTED)).toBe(
+        `Error: expected <Target> type but ${omitted} was passed.`,
+      );
+    });
+  });
+
+  describe('message formats that depend on the print budget', () => {
+    // A type that accepts several shapes cannot rely on the runtime type
+    // alone once the value is omitted — `<string>` reads as acceptable for a
+    // union of string literals — so those messages state why the value was
+    // rejected instead. The `key` / `value` wording of record and Map entries
+    // does not interact with the budget and is covered by the codec tests.
+    test.each([
+      {
+        name: 'no details',
+        actualValue: 'purple',
+        expectedType: 'Color',
+        details: undefined,
+        printed:
+          'Error: expected <Color> type but <string> type value "purple" was passed.',
+        omitted:
+          'Error: expected <Color> type but a string of length 6 was passed.',
+      },
+      {
+        name: 'template-literal',
+        actualValue: 'users',
+        expectedType: 'PathString',
+        details: { kind: 'template-literal' },
+        printed:
+          'Error: expected <PathString> but <string> type value "users" was passed.',
+        omitted:
+          'Error: expected <PathString> but a string of length 5 was passed.',
+      },
+      {
+        name: 'enum',
+        actualValue: 'purple',
+        expectedType: 'Color',
+        details: { kind: 'enum', values: ['red', 'green', 'blue'] },
+        printed:
+          'Error: expected one of { red, green, blue } but "purple" was passed.',
+        omitted:
+          'Error: expected one of { red, green, blue } but a string of length 6 matching none of them was passed.',
+      },
+      {
+        name: 'integer-range',
+        actualValue: 42,
+        expectedType: 'Digit',
+        details: { kind: 'integer-range', start: 0, endExclusive: 10 },
+        printed:
+          'Error: expected an integer between 0 and 9 but `42` was passed.',
+        omitted:
+          'Error: expected an integer between 0 and 9 but a value of type <number> was passed.',
+      },
+      {
+        name: 'union',
+        actualValue: 'purple',
+        expectedType: '("red" | "green")',
+        details: { kind: 'union', typeNames: ['"red"', '"green"'] },
+        printed:
+          'Error: expected one of <"red">, <"green"> but <string> type value "purple" was passed.',
+        omitted:
+          'Error: expected one of <"red">, <"green"> but a string of length 6 matching none of them was passed.',
+      },
+      {
+        name: 'union-category-mismatch',
+        actualValue: 42,
+        expectedType: 'Shape',
         details: {
-          kind: 'custom',
-          message: 'Oops',
+          kind: 'union-category-mismatch',
+          memberCount: 3,
+          memberCategories: ['object'],
         },
+        printed:
+          'Error: the value did not match any of the 3 members of the union; expected a value of type <object> but <number> type value `42` was passed.',
+        omitted:
+          'Error: the value did not match any of the 3 members of the union; expected a value of type <object> but a value of type <number> was passed.',
       },
-      20,
-    );
-
-    expect(msg).toBe('Error at a.b: Oops');
-  });
-
-  test('omits long string actual value beyond max length', () => {
-    const long = 'x'.repeat(50);
-
-    const msg = validationErrorToMessage(
       {
-        path: [],
-        actualValue: long,
+        name: 'intersection',
+        actualValue: { a: 1 },
+        expectedType: '(A & B)',
+        details: { kind: 'intersection', typeNames: ['A', 'B'] },
+        printed:
+          'Error: expected value to match all types of <A>, <B> but <object> type value `{"a":1}` was passed.',
+        omitted:
+          'Error: expected value to match all types of <A>, <B> but a value of type <object> not matching all of them was passed.',
+      },
+      {
+        name: 'record-entry',
+        actualValue: 42,
+        expectedType: 'Dict',
+        details: { kind: 'record-entry', entry: 'key', expectedType: 'string' },
+        printed:
+          'Error: expected record key type to be <string> but <number> type value `42` was passed.',
+        omitted:
+          'Error: expected record key type to be <string> but a value of type <number> was passed.',
+      },
+      {
+        name: 'map-entry',
+        actualValue: 'purple',
+        expectedType: 'Counts',
+        details: { kind: 'map-entry', entry: 'value', expectedType: 'number' },
+        printed:
+          'Error: expected Map value type to be <number> but <string> type value "purple" was passed.',
+        omitted:
+          'Error: expected Map value type to be <number> but a string of length 6 was passed.',
+      },
+      {
+        name: 'set-element',
+        actualValue: 'purple',
+        expectedType: 'Ids',
+        details: { kind: 'set-element', expectedType: 'number' },
+        printed:
+          'Error: expected Set element type to be <number> but <string> type value "purple" was passed.',
+        omitted:
+          'Error: expected Set element type to be <number> but a string of length 6 was passed.',
+      },
+      {
+        name: 'string-constraint (length-carrying)',
+        actualValue: 'ab',
         expectedType: 'string',
-        typeName: 'string',
-        details: undefined,
-      },
-      10,
-    );
-
-    expect(msg).toBe(
-      'Error: expected <string> type but <string> type value was passed.',
-    );
-  });
-
-  test('non-string actual value omitted when too long for unknownToString', () => {
-    const bigNumber = 123_456_789_012_345_678_901; // length > 10 as string
-
-    const msg = validationErrorToMessage(
-      {
-        path: ['p'],
-        actualValue: bigNumber,
-        expectedType: 'number',
-        typeName: 'number',
-        details: undefined,
-      },
-      5,
-    );
-
-    expect(msg).toBe(
-      'Error at p: expected <number> type but <number> type value was passed.',
-    );
-  });
-
-  test('string-constraint detail renders a constraint-specific message', () => {
-    const msg = validationErrorToMessage(
-      {
-        path: ['name'],
-        actualValue: '',
-        expectedType: 'string',
-        typeName: 'string',
         details: {
           kind: 'string-constraint',
-          violation: { constraint: 'nonempty', value: true },
+          violation: { constraint: 'minLength', value: 3 },
         },
+        printed:
+          'Error: expected a string of length 3 or more but a string of length 2 "ab" was passed.',
+        omitted:
+          'Error: expected a string of length 3 or more but a string of length 2 was passed.',
       },
-      20,
-    );
-
-    expect(msg).toBe(
-      'Error at name: expected a non-empty string but an empty string was passed.',
-    );
-  });
-
-  test('string-constraint minLength reports the actual length even for a long value', () => {
-    const long = 'x'.repeat(50);
-
-    const msg = validationErrorToMessage(
       {
-        path: [],
-        actualValue: long,
+        name: 'string-constraint (value-carrying)',
+        actualValue: 'purple',
         expectedType: 'string',
-        typeName: 'string',
         details: {
           kind: 'string-constraint',
-          violation: { constraint: 'minLength', value: 100 },
+          violation: { constraint: 'startsWith', value: 'https://' },
         },
+        printed:
+          'Error: expected a string starting with "https://" but "purple" was passed.',
+        omitted:
+          'Error: expected a string starting with "https://" but a string of length 6 was passed.',
       },
-      10,
-    );
-
-    // The value itself is omitted (too long), but the length is still shown.
-    expect(msg).toBe(
-      'Error: expected a string of length 100 or more but a string of length 50 was passed.',
-    );
-  });
-
-  test('numeric-constraint detail renders the numeric-type noun', () => {
-    const msg = validationErrorToMessage(
       {
-        path: ['count'],
+        name: 'numeric-constraint',
         actualValue: -1n,
         expectedType: 'bigint',
-        typeName: 'bigint',
         details: {
           kind: 'numeric-constraint',
           numericType: 'bigint',
           violation: { constraint: 'positive', value: true },
         },
+        printed: 'Error: expected a positive bigint but `-1n` was passed.',
+        omitted:
+          'Error: expected a positive bigint but a value of type <bigint> was passed.',
       },
-      20,
+    ] as const satisfies readonly FormattingCase[])(
+      '$name',
+      ({ actualValue, expectedType, details, printed, omitted }) => {
+        const error = errorOf({ actualValue, expectedType, details });
+
+        expect(validationErrorToMessage(error, PRINTED)).toBe(printed);
+
+        expect(validationErrorToMessage(error, OMITTED)).toBe(omitted);
+      },
+    );
+  });
+
+  describe('message formats that never include the value', () => {
+    // The remaining kinds describe the failure entirely on their own, so the
+    // print budget cannot change them.
+    test.each([
+      {
+        name: 'custom',
+        details: { kind: 'custom', message: 'Oops' },
+        message: 'Error: Oops',
+      },
+      {
+        name: 'tuple-length',
+        details: { kind: 'tuple-length', expectedLength: 2, actualLength: 3 },
+        message: 'Error: expected tuple of length 2 but length 3 was passed.',
+      },
+      {
+        name: 'array-length',
+        details: { kind: 'array-length', expectedLength: 2, actualLength: 3 },
+        message: 'Error: expected array of length 2 but length 3 was passed.',
+      },
+      {
+        name: 'array-min-length',
+        details: { kind: 'array-min-length', minLength: 4, actualLength: 3 },
+        message:
+          'Error: expected array of length 4 or more but length 3 was passed.',
+      },
+      {
+        name: 'array-max-length',
+        details: { kind: 'array-max-length', maxLength: 2, actualLength: 3 },
+        message:
+          'Error: expected array of length 2 or less but length 3 was passed.',
+      },
+      {
+        name: 'array-range-length',
+        details: {
+          kind: 'array-range-length',
+          minLength: 4,
+          maxLength: 6,
+          actualLength: 3,
+        },
+        message:
+          'Error: expected array of length between 4 and 6 but length 3 was passed.',
+      },
+      {
+        name: 'non-empty-array',
+        details: { kind: 'non-empty-array' },
+        message: 'Error: expected non-empty array but empty array was passed.',
+      },
+      {
+        name: 'missing-key',
+        details: { kind: 'missing-key', key: 'x' },
+        message: 'Error: missing required key "x".',
+      },
+      {
+        name: 'excess-key',
+        details: { kind: 'excess-key', key: 'x' },
+        message: 'Error: excess property "x" is not allowed.',
+      },
+      {
+        name: 'union-closest-member',
+        details: {
+          kind: 'union-closest-member',
+          memberCount: 3,
+          closestMemberTypeName: '{ kind: "circle" }',
+          equallyCloseMemberTypeNames: [],
+        },
+        message:
+          'Error: the value did not match any of the 3 members of the union; the closest member type is <{ kind: "circle" }>, which failed as follows:',
+      },
+      {
+        name: 'brand',
+        details: { kind: 'brand', description: 'must be even' },
+        message: 'Error: expected value to satisfy constraint: must be even.',
+      },
+      {
+        name: 'string-constraint (nonempty)',
+        details: {
+          kind: 'string-constraint',
+          violation: { constraint: 'nonempty', value: true },
+        },
+        message:
+          'Error: expected a non-empty string but an empty string was passed.',
+      },
+    ] as const satisfies readonly InvariantCase[])(
+      '$name',
+      ({ details, message }) => {
+        const error = errorOf({
+          actualValue: 'a value long enough to be omitted',
+          expectedType: 'Target',
+          details,
+        });
+
+        expect(validationErrorToMessage(error, PRINTED)).toBe(message);
+
+        expect(validationErrorToMessage(error, OMITTED)).toBe(message);
+      },
+    );
+  });
+
+  test('the path is prefixed to the message', () => {
+    const error: ValidationError = {
+      path: ['user', 'address', 'street'],
+      actualValue: 42,
+      expectedType: 'string',
+      typeName: 'string',
+      details: undefined,
+    } as const;
+
+    expect(validationErrorToMessage(error)).toBe(
+      'Error at user.address.street: expected <string> type but <number> type value `42` was passed.',
+    );
+  });
+
+  test('the print budget defaults to 20 characters', () => {
+    const error = errorOf({
+      actualValue: 'x'.repeat(21),
+      expectedType: 'Target',
+      details: undefined,
+    });
+
+    expect(validationErrorToMessage(error)).toBe(
+      'Error: expected <Target> type but a string of length 21 was passed.',
     );
 
-    expect(msg).toBe(
-      'Error at count: expected a positive bigint but `-1n` was passed.',
+    expect(
+      validationErrorToMessage(
+        errorOf({
+          actualValue: 'x'.repeat(20),
+          expectedType: 'Target',
+          details: undefined,
+        }),
+      ),
+    ).toBe(
+      `Error: expected <Target> type but <string> type value "${'x'.repeat(20)}" was passed.`,
     );
   });
 });
+
+type FormattingCase = Readonly<{
+  name: string;
+  actualValue: unknown;
+  expectedType: string;
+  details: ValidationErrorDetails | undefined;
+  printed: string;
+  omitted: string;
+}>;
+
+type InvariantCase = Readonly<{
+  name: string;
+  details: ValidationErrorDetails;
+  message: string;
+}>;

--- a/packages/ts-fortress/src/utils/validation-error.mts
+++ b/packages/ts-fortress/src/utils/validation-error.mts
@@ -1,4 +1,6 @@
+import { isMap, isSet } from '@sindresorhus/is';
 import { Arr, isString, match, pipe, unknownToString } from 'ts-data-forge';
+import { toUnionString } from './to-union-string.mjs';
 
 export type ValidationErrorDetails = Readonly<
   | {
@@ -61,6 +63,23 @@ export type ValidationErrorDetails = Readonly<
   | {
       kind: 'union';
       typeNames: readonly string[];
+    }
+  | {
+      kind: 'union-category-mismatch';
+      memberCount: number;
+      memberCategories: readonly string[];
+    }
+  | {
+      kind: 'union-closest-member';
+      memberCount: number;
+      /** The member whose errors follow the message. */
+      closestMemberTypeName: string;
+      /**
+       * Members that produced the same number of errors as
+       * {@link ValidationErrorDetails.closestMemberTypeName} and are therefore
+       * just as plausible. Empty when the closest member is unambiguous.
+       */
+      equallyCloseMemberTypeNames: readonly string[];
     }
   | {
       kind: 'record-entry';
@@ -171,42 +190,159 @@ export const validationErrorToMessage = (
     ? (`Error at ${error.path.join('.')}: ` as const)
     : 'Error: ';
 
-  const detailsMessage = createDetailsMessage(
-    error,
+  const actualValue = describeActualValue(
+    error.actualValue,
     maxLengthToPrintActualValue,
   );
 
-  if (detailsMessage !== undefined) {
-    return `${pathPrefix}${detailsMessage}`;
+  const detailsMessage = createDetailsMessage(error, actualValue);
+
+  return `${pathPrefix}${
+    detailsMessage ??
+    `expected <${error.expectedType}> type but ${typedValueClause(actualValue)} was passed.`
+  }`;
+};
+
+/**
+ * Human-readable name for the runtime type of a value.
+ *
+ * `typeof` reports a bare `"object"` for `null` and for every non-primitive,
+ * which makes an error message unable to distinguish a plain object from
+ * `null` or from the basic containers, so those are named individually.
+ */
+export const runtimeTypeNameOf = (value: unknown): string =>
+  value === null
+    ? 'null'
+    : Arr.isArray(value)
+      ? 'array'
+      : isMap(value)
+        ? 'Map'
+        : isSet(value)
+          ? 'Set'
+          : typeof value;
+
+/** A value as it is rendered inside an error message. */
+type ActualValueView = Readonly<{
+  /** See {@link runtimeTypeNameOf}. */
+  typeName: string;
+
+  /**
+   * The value itself (`"purple"`, `` `5` ``), or `''` when it is longer than
+   * the configured maximum print length.
+   */
+  literal: string;
+
+  /**
+   * Replaces {@link literal} when the value is too long to print. Keeps the
+   * message informative by describing the value's size instead of dropping it
+   * entirely (e.g. `a string of length 50`).
+   */
+  summary: string;
+}>;
+
+const describeActualValue = (
+  actualValue: unknown,
+  maxLengthToPrintActualValue: number,
+): ActualValueView =>
+  ({
+    typeName: runtimeTypeNameOf(actualValue),
+    literal: isString(actualValue)
+      ? actualValue.length <= maxLengthToPrintActualValue
+        ? (`"${actualValue}"` as const)
+        : ('' as const)
+      : pipe(unknownToString(actualValue)).map((s) =>
+          s.length <= maxLengthToPrintActualValue ? (`\`${s}\`` as const) : '',
+        ).value,
+    summary: summarizeActualValue(actualValue),
+  }) as const;
+
+const summarizeActualValue = (actualValue: unknown): string =>
+  isString(actualValue)
+    ? (`a string of length ${actualValue.length}` as const)
+    : Arr.isArray(actualValue)
+      ? (`an array of length ${actualValue.length}` as const)
+      : isMap(actualValue)
+        ? (`a Map of size ${actualValue.size}` as const)
+        : isSet(actualValue)
+          ? (`a Set of size ${actualValue.size}` as const)
+          : (`a value of type <${runtimeTypeNameOf(actualValue)}>` as const);
+
+/**
+ * Renders the subject of the trailing `"... was passed."` clause, prefixed
+ * with the value's runtime type (`<string> type value "purple"`).
+ *
+ * `unmatchedReason` is used only when the value is too long to print: for a
+ * type that accepts several shapes (a union, an enum, an intersection),
+ * naming the runtime type alone reads as if that type were acceptable, so the
+ * reason why the value was rejected has to be spelled out instead.
+ */
+const typedValueClause = (
+  actualValue: ActualValueView,
+  unmatchedReason?: string,
+): string =>
+  actualValue.literal === ''
+    ? withUnmatchedReason(actualValue.summary, unmatchedReason)
+    : (`<${actualValue.typeName}> type value ${actualValue.literal}` as const);
+
+/** Same as {@link typedValueClause}, but without the leading type name. */
+const bareValueClause = (
+  actualValue: ActualValueView,
+  unmatchedReason?: string,
+): string =>
+  actualValue.literal === ''
+    ? withUnmatchedReason(actualValue.summary, unmatchedReason)
+    : actualValue.literal;
+
+const withUnmatchedReason = (
+  summary: string,
+  unmatchedReason: string | undefined,
+): string =>
+  unmatchedReason === undefined
+    ? summary
+    : (`${summary} ${unmatchedReason}` as const);
+
+/**
+ * Maximum length of the ` | `-joined listing of union member type names that a
+ * message may spell out. Beyond it a listing is more noise than help, so both
+ * users of this bound summarize instead: `union` switches from listing every
+ * member to reporting the closest one, and the closest-member message stops
+ * naming the members that tie with it.
+ */
+export const UNION_MEMBER_LISTING_MAX_LENGTH = 60;
+
+/**
+ * Names the closest union member, plus the members that are just as close.
+ *
+ * The tie is a subset of members that were already too many to list, so the
+ * bound is applied to the names this clause *adds* — the closest member is
+ * named either way.
+ */
+const closestMemberClause = (
+  closestMemberTypeName: string,
+  equallyCloseMemberTypeNames: readonly string[],
+): string => {
+  if (!Arr.isNonEmpty(equallyCloseMemberTypeNames)) {
+    return `the closest member type is <${closestMemberTypeName}>, which failed as follows:`;
   }
 
-  const actualTypeStr = typeof error.actualValue;
+  if (
+    toUnionString(equallyCloseMemberTypeNames).length >
+    UNION_MEMBER_LISTING_MAX_LENGTH
+  ) {
+    return `${equallyCloseMemberTypeNames.length + 1} members are equally close; <${closestMemberTypeName}> failed as follows:`;
+  }
 
-  const actualValueStr: string = isString(error.actualValue)
-    ? error.actualValue.length <= maxLengthToPrintActualValue
-      ? (` "${error.actualValue}"` as const)
-      : ''
-    : pipe(unknownToString(error.actualValue)).map((s) =>
-        s.length <= maxLengthToPrintActualValue ? ` \`${s}\`` : '',
-      ).value;
+  const allTypeNames = Arr.toUnshifted(closestMemberTypeName)(
+    equallyCloseMemberTypeNames,
+  );
 
-  return `${pathPrefix}expected <${error.expectedType}> type but <${actualTypeStr}> type value${actualValueStr} was passed.`;
+  return `the closest member types are <${allTypeNames.join('>, <')}>; the first of them failed as follows:`;
 };
 
 const createDetailsMessage = (
   error: ValidationError,
-  maxLengthToPrintActualValue: number,
+  actualValue: ActualValueView,
 ): string | undefined => {
-  const actualTypeStr = typeof error.actualValue;
-
-  const actualValueStr: string = isString(error.actualValue)
-    ? error.actualValue.length <= maxLengthToPrintActualValue
-      ? (` "${error.actualValue}"` as const)
-      : ''
-    : pipe(unknownToString(error.actualValue)).map((s) =>
-        s.length <= maxLengthToPrintActualValue ? ` \`${s}\`` : '',
-      ).value;
-
   switch (error.details?.kind) {
     case undefined:
       return undefined;
@@ -215,10 +351,10 @@ const createDetailsMessage = (
       return error.details.message;
 
     case 'template-literal':
-      return `expected <${error.expectedType}> but <${actualTypeStr}> type value${actualValueStr} was passed.`;
+      return `expected <${error.expectedType}> but ${typedValueClause(actualValue)} was passed.`;
 
     case 'integer-range':
-      return `expected an integer between ${error.details.start} and ${error.details.endExclusive - 1} but${actualValueStr} was passed.`;
+      return `expected an integer between ${error.details.start} and ${error.details.endExclusive - 1} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'tuple-length':
       return `expected tuple of length ${error.details.expectedLength} but length ${error.details.actualLength} was passed.`;
@@ -245,30 +381,41 @@ const createDetailsMessage = (
       return `excess property "${error.details.key}" is not allowed.`;
 
     case 'intersection':
-      return `expected value to match all types of <${error.details.typeNames.join('>, <')}> but <${actualTypeStr}> type value${actualValueStr} was passed.`;
+      return `expected value to match all types of <${error.details.typeNames.join('>, <')}> but ${typedValueClause(actualValue, 'not matching all of them')} was passed.`;
 
     case 'enum':
       return `expected one of { ${error.details.values
         .map(String)
-        .join(', ')} } but${actualValueStr} was passed.`;
+        .join(
+          ', ',
+        )} } but ${bareValueClause(actualValue, 'matching none of them')} was passed.`;
 
     case 'union':
-      return `expected one of <${error.details.typeNames.join('>, <')}> but <${actualTypeStr}> type value${actualValueStr} was passed.`;
+      return `expected one of <${error.details.typeNames.join('>, <')}> but ${typedValueClause(actualValue, 'matching none of them')} was passed.`;
+
+    case 'union-category-mismatch':
+      return `the value did not match any of the ${error.details.memberCount} members of the union; expected a value of type <${error.details.memberCategories.join('> | <')}> but ${typedValueClause(actualValue)} was passed.`;
+
+    case 'union-closest-member':
+      return `the value did not match any of the ${error.details.memberCount} members of the union; ${closestMemberClause(
+        error.details.closestMemberTypeName,
+        error.details.equallyCloseMemberTypeNames,
+      )}`;
 
     case 'record-entry':
       return match(error.details.entry, {
-        key: `expected record key type to be <${error.details.expectedType}> but <${actualTypeStr}> type value${actualValueStr} was passed.`,
-        value: `expected record value type to be <${error.details.expectedType}> but <${actualTypeStr}> type value${actualValueStr} was passed.`,
+        key: `expected record key type to be <${error.details.expectedType}> but ${typedValueClause(actualValue)} was passed.`,
+        value: `expected record value type to be <${error.details.expectedType}> but ${typedValueClause(actualValue)} was passed.`,
       });
 
     case 'map-entry':
       return match(error.details.entry, {
-        key: `expected Map key type to be <${error.details.expectedType}> but <${actualTypeStr}> type value${actualValueStr} was passed.`,
-        value: `expected Map value type to be <${error.details.expectedType}> but <${actualTypeStr}> type value${actualValueStr} was passed.`,
+        key: `expected Map key type to be <${error.details.expectedType}> but ${typedValueClause(actualValue)} was passed.`,
+        value: `expected Map value type to be <${error.details.expectedType}> but ${typedValueClause(actualValue)} was passed.`,
       });
 
     case 'set-element':
-      return `expected Set element type to be <${error.details.expectedType}> but <${actualTypeStr}> type value${actualValueStr} was passed.`;
+      return `expected Set element type to be <${error.details.expectedType}> but ${typedValueClause(actualValue)} was passed.`;
 
     case 'brand':
       return `expected value to satisfy constraint: ${error.details.description}.`;
@@ -277,102 +424,109 @@ const createDetailsMessage = (
       return stringConstraintToMessage(
         error.details.violation,
         error.actualValue,
-        actualValueStr,
+        actualValue,
       );
 
     case 'numeric-constraint':
       return numericConstraintToMessage(
         error.details.numericType,
         error.details.violation,
-        actualValueStr,
+        actualValue,
       );
   }
 };
 
 const stringConstraintToMessage = (
   violation: StringConstraintViolation,
-  actualValue: unknown,
-  actualValueStr: string,
+  rawActualValue: unknown,
+  actualValue: ActualValueView,
 ): string => {
-  const actualLength = isString(actualValue) ? actualValue.length : 0;
+  const actualLength = isString(rawActualValue) ? rawActualValue.length : 0;
+
+  // The length carries the constraint violation, so the value itself is only
+  // appended when it is short enough to print.
+  const lengthClause =
+    actualValue.literal === ''
+      ? (`a string of length ${actualLength}` as const)
+      : (`a string of length ${actualLength} ${actualValue.literal}` as const);
 
   switch (violation.constraint) {
     case 'nonempty':
       return 'expected a non-empty string but an empty string was passed.';
 
     case 'minLength':
-      return `expected a string of length ${violation.value} or more but a string of length ${actualLength}${actualValueStr} was passed.`;
+      return `expected a string of length ${violation.value} or more but ${lengthClause} was passed.`;
 
     case 'maxLength':
-      return `expected a string of length ${violation.value} or less but a string of length ${actualLength}${actualValueStr} was passed.`;
+      return `expected a string of length ${violation.value} or less but ${lengthClause} was passed.`;
 
     case 'startsWith':
-      return `expected a string starting with "${violation.value}" but${actualValueStr} was passed.`;
+      return `expected a string starting with "${violation.value}" but ${bareValueClause(actualValue)} was passed.`;
 
     case 'endsWith':
-      return `expected a string ending with "${violation.value}" but${actualValueStr} was passed.`;
+      return `expected a string ending with "${violation.value}" but ${bareValueClause(actualValue)} was passed.`;
 
     case 'includes':
-      return `expected a string containing "${violation.value}" but${actualValueStr} was passed.`;
+      return `expected a string containing "${violation.value}" but ${bareValueClause(actualValue)} was passed.`;
 
     case 'uppercase':
-      return `expected an uppercase string but${actualValueStr} was passed.`;
+      return `expected an uppercase string but ${bareValueClause(actualValue)} was passed.`;
 
     case 'lowercase':
-      return `expected a lowercase string but${actualValueStr} was passed.`;
+      return `expected a lowercase string but ${bareValueClause(actualValue)} was passed.`;
 
     case 'regex':
-      return `expected a string matching /${violation.value}/ but${actualValueStr} was passed.`;
+      return `expected a string matching /${violation.value}/ but ${bareValueClause(actualValue)} was passed.`;
   }
 };
 
 const numericConstraintToMessage = (
   numericType: 'bigint' | 'number',
   violation: NumericConstraintViolation,
-  actualValueStr: string,
+  actualValue: ActualValueView,
 ): string => {
   switch (violation.constraint) {
     case 'finite':
-      return `expected a finite number but${actualValueStr} was passed.`;
+      return `expected a finite number but ${bareValueClause(actualValue)} was passed.`;
 
     case 'int':
-      return `expected an integer but${actualValueStr} was passed.`;
+      return `expected an integer but ${bareValueClause(actualValue)} was passed.`;
 
     case 'safeInteger':
-      return `expected a safe integer but${actualValueStr} was passed.`;
+      return `expected a safe integer but ${bareValueClause(actualValue)} was passed.`;
 
     case 'nonZero':
-      return `expected a non-zero ${numericType} but${actualValueStr} was passed.`;
+      return `expected a non-zero ${numericType} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'negative':
-      return `expected a negative ${numericType} but${actualValueStr} was passed.`;
+      return `expected a negative ${numericType} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'nonNegative':
-      return `expected a non-negative ${numericType} but${actualValueStr} was passed.`;
+      return `expected a non-negative ${numericType} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'positive':
-      return `expected a positive ${numericType} but${actualValueStr} was passed.`;
+      return `expected a positive ${numericType} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'nonPositive':
-      return `expected a non-positive ${numericType} but${actualValueStr} was passed.`;
+      return `expected a non-positive ${numericType} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'gt':
-      return `expected a ${numericType} greater than ${violation.value} but${actualValueStr} was passed.`;
+      return `expected a ${numericType} greater than ${violation.value} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'gte':
     case 'min':
-      return `expected a ${numericType} greater than or equal to ${violation.value} but${actualValueStr} was passed.`;
+      return `expected a ${numericType} greater than or equal to ${violation.value} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'lt':
-      return `expected a ${numericType} less than ${violation.value} but${actualValueStr} was passed.`;
+      return `expected a ${numericType} less than ${violation.value} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'lte':
     case 'max':
-      return `expected a ${numericType} less than or equal to ${violation.value} but${actualValueStr} was passed.`;
+      return `expected a ${numericType} less than or equal to ${violation.value} but ${bareValueClause(actualValue)} was passed.`;
 
     case 'multipleOf':
     case 'step':
-      return `expected a ${numericType} to be a multiple of ${violation.value} but${actualValueStr} was passed.`;
+      return `expected a ${numericType} to be a multiple of ${violation.value} but ${bareValueClause(actualValue)} was passed.`;
   }
 };
 

--- a/packages/ts-fortress/src/utils/validation-error.test.mts
+++ b/packages/ts-fortress/src/utils/validation-error.test.mts
@@ -150,7 +150,7 @@ describe('validation-error', () => {
       assert.deepStrictEqual(validationErrorsToMessages(errors), [
         'Error at user.name: expected <string> type but <number> type value `123` was passed.',
         'Error at items.0: expected <number> type but <string> type value "invalid" was passed.',
-        'Error: expected <boolean> type but <object> type value `null` was passed.',
+        'Error: expected <boolean> type but <null> type value `null` was passed.',
       ]);
     });
 

--- a/packages/ts-fortress/test/combination.test.mts
+++ b/packages/ts-fortress/test/combination.test.mts
@@ -419,16 +419,16 @@ describe('advanced type', () => {
     assert.deepStrictEqual(messages, [
       'Error at status: expected one of <enum>, <null>, <undefined> but <string> type value "unknown" was passed.',
       'Error at coordinates.1: expected an integer between -128 and 127 but `190` was passed.',
-      'Error at palette: expected value to match all types of <NonEmptyArray<EvenRange>>, <FixedLengthArray<2, EvenRange>> but <object> type value `[1,3,5]` was passed.',
+      'Error at palette: expected value to match all types of <NonEmptyArray<EvenRange>>, <FixedLengthArray<2, EvenRange>> but <array> type value `[1,3,5]` was passed.',
       'Error at palette.0: expected <EvenRange> type but <number> type value `1` was passed.',
       'Error at palette.1: expected <EvenRange> type but <number> type value `3` was passed.',
       'Error at palette.2: expected <EvenRange> type but <number> type value `5` was passed.',
-      'Error at palette: expected value to match all types of <NonEmptyArray<EvenRange>>, <FixedLengthArray<2, EvenRange>> but <object> type value `[1,3,5]` was passed.',
+      'Error at palette: expected value to match all types of <NonEmptyArray<EvenRange>>, <FixedLengthArray<2, EvenRange>> but <array> type value `[1,3,5]` was passed.',
       'Error at palette: expected array of length 2 but length 3 was passed.',
       'Error at metrics: expected one of <key-value-record>, <undefined> but <object> type value `{"alpha":1}` was passed.',
-      'Error at tags: expected one of <NonEmptyArray<Tag>>, <undefined> but <object> type value `[]` was passed.',
-      'Error at extras: expected one of <key-value-record>, <undefined> but <object> type value was passed.',
-      'Error at children: expected one of <AdvancedNode[]>, <undefined> but <object> type value `[{}]` was passed.',
+      'Error at tags: expected one of <NonEmptyArray<Tag>>, <undefined> but <array> type value `[]` was passed.',
+      'Error at extras: expected one of <key-value-record>, <undefined> but a value of type <object> matching none of them was passed.',
+      'Error at children: expected one of <AdvancedNode[]>, <undefined> but <array> type value `[{}]` was passed.',
     ]);
   });
 


### PR DESCRIPTION
Add tests that capture the current error messages produced when a value
fails to match a union type, covering long discriminated unions (value
close to one member, discriminant-based selection, typeof mismatch,
union nested in a record) and a short literal union. These serve as the
baseline for the upcoming union error message improvement so the
before/after comparison is visible in the commit diff.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016UwUjWktPdU892udcMsHkD