### PR TITLE
chore: replace doc generation with fmt:diff and add test:browser in check-all

### DIFF
--- a/scripts/cmd/check-all.mts
+++ b/scripts/cmd/check-all.mts
@@ -51,9 +51,15 @@ const checkAll = async (): Promise<void> => {
   });
 
   await logStep({
-    startMessage: 'Generating documentation',
-    action: () => runCmdStep('pnpm run doc', 'Documentation generation failed'),
-    successMessage: 'Documentation generated',
+    startMessage: 'Running test:browser',
+    action: () => runCmdStep('pnpm run test:browser', 'Browser tests failed'),
+    successMessage: 'Browser tests passed',
+  });
+
+  await logStep({
+    startMessage: 'Formatting code',
+    action: () => runCmdStep('pnpm run fmt:diff', 'File formatting failed'),
+    successMessage: 'Code formatted',
   });
 
   console.log('✅ All checks completed successfully!\n');


### PR DESCRIPTION
## Summary
- Remove the typedoc documentation-generation step from the local `check-all` script.
- Add a `fmt:diff` formatting step (replacing `fmt:full` in monorepo repos).
- Add a `test:browser` step where a `test:browser` script exists.

This only affects the local `scripts/cmd/check-all.mts` convenience runner; CI is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)