### PR TITLE
refactor: re-export IntRange from ts-type-forge

### DIFF
--- a/.changeset/int-range-from-ts-type-forge.md
+++ b/.changeset/int-range-from-ts-type-forge.md
@@ -7,8 +7,8 @@ declared locally, mirroring how `UintRange` is already handled. The exported
 type name and its semantics are unchanged.
 
 Requires `ts-type-forge` 8.0.0, the release that adds `IntRange`. That release
-also constrains the bounds of the whole integer-range family (`Uint10` for
-`UintRange` / `UintRangeInclusive`, `Int10` for `IntRange` /
-`IntRangeInclusive`); `intRange()` and `uintRange()` already constrain their own
-bounds to `Int8` / `Uint8`, which sit inside the new caps, so neither function's
-signature changes.
+also constrains the bounds of the whole integer-range family (`Uint11`, `0` to
+`2047`, for `UintRange` / `UintRangeInclusive`; `Int11`, `-1024` to `1023`, for
+`IntRange` / `IntRangeInclusive`); `intRange()` and `uintRange()` already
+constrain their own bounds to `Int8` / `Uint8`, which sit well inside the new
+caps, so neither function's signature changes.

--- a/.changeset/int-range-from-ts-type-forge.md
+++ b/.changeset/int-range-from-ts-type-forge.md
@@ -6,4 +6,9 @@
 declared locally, mirroring how `UintRange` is already handled. The exported
 type name and its semantics are unchanged.
 
-Requires `ts-type-forge` >= 7.3.0, the release that adds `IntRange`.
+Requires `ts-type-forge` 8.0.0, the release that adds `IntRange`. That release
+also constrains the bounds of the whole integer-range family (`Uint10` for
+`UintRange` / `UintRangeInclusive`, `Int10` for `IntRange` /
+`IntRangeInclusive`); `intRange()` and `uintRange()` already constrain their own
+bounds to `Int8` / `Uint8`, which sit inside the new caps, so neither function's
+signature changes.

--- a/.changeset/int-range-from-ts-type-forge.md
+++ b/.changeset/int-range-from-ts-type-forge.md
@@ -1,0 +1,9 @@
+---
+'ts-fortress': patch
+---
+
+`IntRange<Start, End>` is now re-exported from `ts-type-forge` instead of being
+declared locally, mirroring how `UintRange` is already handled. The exported
+type name and its semantics are unchanged.
+
+Requires `ts-type-forge` >= 7.3.0, the release that adds `IntRange`.

--- a/packages/ts-fortress/package.json
+++ b/packages/ts-fortress/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@sindresorhus/is": "8.1.x",
     "ts-data-forge": "12.x",
-    "ts-type-forge": "7.x"
+    "ts-type-forge": "8.x"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "6.0.3",

--- a/packages/ts-fortress/src/enum/int-range.mts
+++ b/packages/ts-fortress/src/enum/int-range.mts
@@ -1,19 +1,5 @@
-import {
-  expectType,
-  isNumber,
-  memoizeFunction,
-  Num,
-  Result,
-} from 'ts-data-forge';
-import {
-  type BoolAnd,
-  type Index,
-  type IndexInclusive,
-  type Int8,
-  type NegativeIndex,
-  type TypeExtends,
-  type UintRange,
-} from 'ts-type-forge';
+import { isNumber, memoizeFunction, Num, Result } from 'ts-data-forge';
+import { type Int8, type IntRange } from 'ts-type-forge';
 import { type Type } from '../type.mjs';
 import {
   createAssertFn,
@@ -21,6 +7,8 @@ import {
   createIsFn,
   type ValidationError,
 } from '../utils/index.mjs';
+
+export type { IntRange } from 'ts-type-forge';
 
 export const intRange = <Start extends Int8, End extends Int8 | 128>({
   end,
@@ -83,46 +71,3 @@ export const intRange = <Start extends Int8, End extends Int8 | 128>({
     cast: createCastFn(validate),
   };
 };
-
-type NegativeRange = NegativeIndex<128>;
-
-type PositiveRange = IndexInclusive<128>;
-
-export type IntRange<Start extends Int8, End extends Int8 | 128> =
-  BoolAnd<
-    TypeExtends<Start, PositiveRange>,
-    TypeExtends<End, PositiveRange>
-  > extends true
-    ? UintRange<Start, End>
-    : BoolAnd<
-          TypeExtends<Start, NegativeRange>,
-          TypeExtends<End, PositiveRange>
-        > extends true
-      ? NegativeIndex<NegativeToPositive<Start>> | Index<End>
-      : BoolAnd<
-            TypeExtends<Start, PositiveRange>,
-            TypeExtends<End, NegativeRange>
-          > extends true
-        ? never
-        : BoolAnd<
-              TypeExtends<Start, NegativeRange>,
-              TypeExtends<End, NegativeRange>
-            > extends true
-          ? Exclude<
-              NegativeIndex<NegativeToPositive<Start>>,
-              NegativeIndex<NegativeToPositive<End>>
-            >
-          : never;
-
-type NegativeToPositive<N extends number> =
-  `${N}` extends `-${infer D extends number}` ? D : never;
-
-expectType<NegativeToPositive<-3>, 3>('=');
-
-expectType<IntRange<1, 5>, 1 | 2 | 3 | 4>('=');
-
-expectType<IntRange<-3, 3>, -3 | -2 | -1 | 0 | 1 | 2>('=');
-
-expectType<IntRange<3, -3>, never>('=');
-
-expectType<IntRange<-5, -1>, -5 | -4 | -3 | -2>('=');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: 12.x
         version: 12.2.2(typescript@6.0.3)
       ts-type-forge:
-        specifier: 7.x
-        version: 7.2.1
+        specifier: 8.x
+        version: 8.0.0
     devDependencies:
       '@rollup/plugin-replace':
         specifier: 6.0.3
@@ -3762,6 +3762,10 @@ packages:
 
   ts-type-forge@7.2.1:
     resolution: {integrity: sha512-XfF2CYB/2YoKNKfbTQNDAyXRNc7qpLZqNWL8FIZYlOPiODfn9B0oAIh4ogduRoXJAg5hunj473rZJ0IAolIslw==}
+    engines: {node: '>=22.22.2', pnpm: '>=9.0.0'}
+
+  ts-type-forge@8.0.0:
+    resolution: {integrity: sha512-6wisIN+EFO+hxhcx5hBQ8fIBaSPBZirUSt0Pt5F3SJr0/C+9K3lwyDPY3DASeUMQi/YonE9mzO49+h0K/7RKGg==}
     engines: {node: '>=22.22.2', pnpm: '>=9.0.0'}
 
   tsconfig-paths@3.15.0:
@@ -7997,6 +8001,8 @@ snapshots:
   ts-type-forge@5.0.0: {}
 
   ts-type-forge@7.2.1: {}
+
+  ts-type-forge@8.0.0: {}
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
## Summary

`IntRange` was declared in `src/enum/int-range.mts` even though it is a pure
type-level utility built entirely out of ts-type-forge primitives (`UintRange`,
`Index`, `IndexInclusive`, `NegativeIndex`, `BoolAnd`, `TypeExtends`). It has
been moved to ts-type-forge and is now re-exported from here, exactly as
`src/enum/uint-range.mts` already does for `UintRange`:

```ts
import { type Int8, type IntRange } from 'ts-type-forge';

export type { IntRange } from 'ts-type-forge';
```

The exported type name, its constraints (`Start` extends `Int8`, `End` extends
`Int8` or 128) and its semantics are unchanged, so this is not a breaking
change for consumers. The `intRange()` implementation and signature are
untouched.

## Changes

- `src/enum/int-range.mts`: drop the local `IntRange` definition, the
  `NegativeRange` / `PositiveRange` / `NegativeToPositive` helpers and the
  type-level `expectType` assertions (the assertions moved to ts-type-forge
  alongside the definition, where they were also extended with empty-range,
  single-element and boundary cases); re-export the type instead
- `packages/ts-fortress/package.json` + `pnpm-lock.yaml`: require
  `ts-type-forge` `8.x` (8.0.0 is the release that adds `IntRange`)
- Changeset: `patch`

## Upstream

noshiro-pf/ts-type-forge#443 added `IntRange` and, in the same release,
constrained the bounds of the whole integer-range family: `Uint11` (0..2047)
for `UintRange` / `UintRangeInclusive`, `Int11` (-1024..1023) for `IntRange` /
`IntRangeInclusive`. That made it a major release — **8.0.0**, now published.

Those constraints do not affect this package: `intRange()` and `uintRange()`
already constrain their own bounds to `Int8` (-128..127) and `Uint8` (0..255),
both well inside the new caps, so neither function's signature changes.

## Verification

`pnpm run check-all` completes successfully against the real `ts-type-forge`
8.0.0 — type check, lint, build, 1642 tests (plus 32 ESLint-plugin rule tests),
codemod and format.
