### PR TITLE
feat(eslint-plugin): export a recommended config preset

### DIFF
--- a/.changeset/eslint-plugin-config-preset.md
+++ b/.changeset/eslint-plugin-config-preset.md
@@ -1,0 +1,17 @@
+---
+'eslint-plugin-ts-fortress': minor
+---
+
+Ship a `recommended` config preset. `eslintPluginTsFortress.configs.recommended`
+is a flat-config object that registers the plugin and enables every rule at
+`error`, so consuming projects can start from:
+
+```ts
+export default [eslintPluginTsFortress.configs.recommended];
+```
+
+The preset registers the exported plugin object itself, so listing the plugin in
+your own `plugins` record alongside the preset does not trigger ESLint's
+`Cannot redefine plugin` error.
+
+Also exports the `ESLintFlatConfig` type alongside the existing `ESLintPlugin`.

--- a/packages/eslint-plugin-ts-fortress/README.md
+++ b/packages/eslint-plugin-ts-fortress/README.md
@@ -15,6 +15,39 @@ configured TypeScript project is not required.
 
 ## Usage (flat config)
 
+The plugin ships a `recommended` config preset that registers the plugin and
+turns on **every** rule at `error`:
+
+```ts
+// eslint.config.mts
+import { eslintPluginTsFortress } from 'eslint-plugin-ts-fortress';
+
+export default [eslintPluginTsFortress.configs.recommended];
+```
+
+Since the preset is a plain flat-config object, individual rules can be
+adjusted by a later config entry:
+
+```ts
+// eslint.config.mts
+import {
+    eslintPluginTsFortress,
+    type EslintTsFortressRules,
+} from 'eslint-plugin-ts-fortress';
+
+export default [
+    eslintPluginTsFortress.configs.recommended,
+    {
+        files: ['src/legacy/**'],
+        rules: {
+            'ts-fortress/prefer-canonical-length-constrained-type': 'off',
+        } satisfies Partial<EslintTsFortressRules>,
+    },
+];
+```
+
+Or register the plugin yourself and pick the rules one by one:
+
 ```ts
 // eslint.config.mts
 import {

--- a/packages/eslint-plugin-ts-fortress/src/index.mts
+++ b/packages/eslint-plugin-ts-fortress/src/index.mts
@@ -4,4 +4,4 @@ export type {
   EslintTsFortressRulesOption,
 } from './rule-types.mjs';
 export { tsFortressRules } from './rules/index.mjs';
-export { type ESLintPlugin } from './types.mjs';
+export { type ESLintFlatConfig, type ESLintPlugin } from './types.mjs';

--- a/packages/eslint-plugin-ts-fortress/src/plugin.mts
+++ b/packages/eslint-plugin-ts-fortress/src/plugin.mts
@@ -1,9 +1,41 @@
 import { tsFortressRules } from './rules/index.mjs';
-import { type ESLintPlugin } from './types.mjs';
+import { type ESLintFlatConfig, type ESLintPlugin } from './types.mjs';
 
-export const eslintPluginTsFortress: ESLintPlugin = {
+/**
+ * Every rule this plugin ships, at `error`.
+ *
+ * The `satisfies` clause below is keyed off {@link tsFortressRules}, so adding
+ * a rule without listing it here fails to type-check.
+ */
+const recommendedRules = {
+  'ts-fortress/prefer-canonical-length-constrained-type': 'error',
+} as const satisfies Readonly<
+  Record<`ts-fortress/${keyof typeof tsFortressRules}`, 'error'>
+>;
+
+const recommendedConfig = {
+  name: 'ts-fortress/recommended',
+  plugins: {
+    // Resolved lazily so that this config registers the *same* object that
+    // `eslintPluginTsFortress` refers to. ESLint rejects a plugin name that
+    // maps to two different objects with `Cannot redefine plugin`, which is
+    // what a user combining this preset with their own
+    // `plugins: { 'ts-fortress': eslintPluginTsFortress }` entry would hit if
+    // the preset embedded a separate copy of the plugin.
+    get 'ts-fortress'(): ESLintPlugin {
+      return eslintPluginTsFortress;
+    },
+  },
+  rules: recommendedRules,
+} as const satisfies ESLintFlatConfig;
+
+export const eslintPluginTsFortress = {
   meta: {
     name: 'eslint-plugin-ts-fortress',
   },
   rules: tsFortressRules,
-} as const;
+  configs: {
+    /** Enables every rule of this plugin at `error`. */
+    recommended: recommendedConfig,
+  },
+} as const satisfies ESLintPlugin;

--- a/packages/eslint-plugin-ts-fortress/src/plugin.test.mts
+++ b/packages/eslint-plugin-ts-fortress/src/plugin.test.mts
@@ -1,0 +1,24 @@
+import { eslintPluginTsFortress } from './plugin.mjs';
+import { tsFortressRules } from './rules/index.mjs';
+
+describe('eslintPluginTsFortress.configs.recommended', () => {
+  const recommended = eslintPluginTsFortress.configs.recommended;
+
+  test('enables every rule of the plugin, and nothing else, at "error"', () => {
+    assert.deepStrictEqual(
+      recommended.rules,
+      Object.fromEntries(
+        Object.keys(tsFortressRules).map((name) => [
+          `ts-fortress/${name}`,
+          'error',
+        ]),
+      ),
+    );
+  });
+
+  test('registers the exported plugin object itself', () => {
+    // Registering a *copy* would make `Cannot redefine plugin` errors possible
+    // for users who also list the plugin in their own `plugins` record.
+    expect(recommended.plugins['ts-fortress']).toBe(eslintPluginTsFortress);
+  });
+});

--- a/packages/eslint-plugin-ts-fortress/src/types.mts
+++ b/packages/eslint-plugin-ts-fortress/src/types.mts
@@ -2,3 +2,5 @@ import { type TSESLint } from '@typescript-eslint/utils';
 import { type DeepReadonly } from 'ts-type-forge';
 
 export type ESLintPlugin = DeepReadonly<TSESLint.FlatConfig.Plugin>;
+
+export type ESLintFlatConfig = DeepReadonly<TSESLint.FlatConfig.Config>;


### PR DESCRIPTION
## Summary

`eslint-plugin-ts-fortress` now ships a config preset, so consumers no longer
have to register the plugin and list every rule by hand:

```ts
// eslint.config.mts
import { eslintPluginTsFortress } from 'eslint-plugin-ts-fortress';

export default [eslintPluginTsFortress.configs.recommended];
```

`recommended` enables **every rule at `error`**. Only one preset is provided —
with every rule at `error`, a separate `all` would be byte-identical and would
only raise the question of which one to use. Individual rules can still be
adjusted by a later config entry, since the preset is a plain flat-config
object.

## Design notes

**The preset registers the exported plugin object itself.**
ESLint throws `Cannot redefine plugin "ts-fortress"` when one plugin name maps
to two *different* objects, so embedding a copy of the plugin in the preset
would break for anyone who combines it with an existing hand-written
`plugins: { 'ts-fortress': eslintPluginTsFortress }` entry. The preset's
`plugins` entry is therefore a lazy getter returning the exported object — no
mutation, identity preserved.

**A forgotten rule fails to type-check.**
The rule record is constrained by
``satisfies Readonly<Record<`ts-fortress/${keyof typeof tsFortressRules}`, 'error'>>``,
so adding a rule to `tsFortressRules` without listing it in the preset is a
compile error.

The generated `EslintTsFortressRules` was deliberately *not* used for that
constraint: for optioned rules it excludes the bare `'error'` string
(`'off' | Linter.Severity | [StringSeverity, Options]`), which would force a
preset to copy each rule's own default options — a drift hazard as soon as a
rule with options is added.

## Changes

- `src/plugin.mts` — the preset
- `src/plugin.test.mts` — asserts the preset covers exactly the plugin's rules,
  all at `error`, and registers the plugin object itself (new)
- `src/types.mts` / `src/index.mts` — add and re-export the `ESLintFlatConfig` type
- `README.md` — document preset / preset-with-overrides / manual registration
- `.changeset/` — minor

## Test plan

- `pnpm run ws:build`, `ws:test`, `ws:lint:fix`, `fmt` all pass; no generated-file drift
- The same preset shape was verified against a real ESLint `Linter` in the
  sibling `ts-data-forge` repo (`src` and built `dist`): the preset alone and
  the preset combined with a hand-written plugin registration both resolve, and
  a preset rule fires at severity 2
- Confirmed the drift guard by removing a rule from the preset (TS2741) and the
  identity requirement by registering a shallow copy of the plugin
  (`Cannot redefine plugin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSHerEEif4V1mdtUJBqVue

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSHerEEif4V1mdtUJBqVue)_