### PR TITLE
docs(agents): note the array combinators' shape and why rewrites stay exact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,6 +558,68 @@ Per package, use `pnpm --filter <name> run <script>` or run from its directory.
 `pnpm run ws:gi` / `pnpm run agents:gen` individually). CI fails if they drift
 from the committed state.
 
+### Workflow
+
+- After completing a series of code changes, run in this order:
+    1. `pnpm run ws:tsc` and `pnpm run ws:test`
+    2. `pnpm run ws:lint:fix`
+    3. `pnpm run codemod:full` — **before** any doc step, see below
+    4. `pnpm run ws:doc:embed:jsdoc`, then `pnpm run ws:doc:embed`, then
+       `pnpm run ws:doc`
+    5. `pnpm run fmt:full`
+    6. `pnpm run check:root` if you touched the root `scripts/` or `configs/`
+    7. `pnpm run ws:build`
+- **The codemod must run before the doc embeds.** `codemod:full`
+  (`append-as-const` / `convert-to-readonly`) rewrites files under `samples/`,
+  so running it _after_ an embed leaves the copy inside the JSDoc block stale
+  — which fails CI's build and doc checks while everything passes locally.
+  This bites whenever a task adds **new** sample files.
+- Run the sequence a second time and confirm `git status` does not grow. These
+  steps feed each other, so one pass is not proof of a fixed point.
+- The JSDoc sample mapping
+  (`packages/ts-fortress/scripts/cmd/embed-examples-in-jsdoc-map.mts`) is
+  **count-exact and order-sensitive per source file**, so splitting or merging
+  a source file breaks the embed even though no example changed.
+
+### The Length-Constrained Array Combinators
+
+`minLengthArray` / `maxLengthArray` / `boundedLengthArray` /
+`fixedLengthArray` in `packages/ts-fortress/src/array/` return the **branded**
+ts-type-forge types, while their `*Tuple` counterparts return the structural
+ones. Two properties are worth knowing before touching them or the ESLint
+rules that rewrite them:
+
+- **The result is a _pure_ brand.** These combinators produce
+  `Type<MinLengthArray<N, A>>` and never intersect the brand with a tuple.
+  That is the opposite of ts-data-forge's `Arr.is*` guards, which narrow to
+  `Brand<…> & Xs` so as to keep the caller's own element types. If you are
+  reasoning about "brand intersected with tuple" types, this repository is not
+  a source of them.
+- **Each combinator is an overload pair keyed on the bound.** A bound inside
+  `SupportedLength` (`0..2048`) can be encoded in the brand; anything larger
+  selects the fallback overload and the length constraint is dropped
+  (`Type<readonly A[]>`). The structural `*Tuple` combinators have the tighter
+  `StructuralPrefixLength` (`0..10`) limit, mirrored as
+  `STRUCTURAL_PREFIX_CAP` in the plugin's `constants.mts`. A rewrite that
+  carries a bound from one combinator to another is only valid while the bound
+  is inside the target's range.
+
+#### Why canonical-form rewrites must be type-identical here
+
+`prefer-canonical-length-constrained-type` only rewrites calls whose result is
+the **very same** `Type<T>`, never one that is merely narrower. That is
+stricter than the equivalent ts-data-forge rules, and the reason is variance:
+`Type<A>` is **not covariant in `A`** (`prune` takes `<B extends A>`, putting
+`A` in a constraint position — see the long note on `Type` in
+`src/type.mts`). So a `Type<Narrower>` is _not_ substitutable for a
+`Type<Wider>`, and "strengthening" a combinator call can break assignability
+at every use site.
+
+A ts-data-forge `Arr.as*` cast has no such problem — it only ever _returns_
+the narrowed value, so a strengthened result stays assignable everywhere the
+old one was, and those rules do allow a few strengthening rewrites. Do not
+port that latitude back here.
+
 ### Validation Error Handling
 
 #### Centralized Error Message Logic

--- a/agents/local-rules.md
+++ b/agents/local-rules.md
@@ -66,6 +66,68 @@ Per package, use `pnpm --filter <name> run <script>` or run from its directory.
 `pnpm run ws:gi` / `pnpm run agents:gen` individually). CI fails if they drift
 from the committed state.
 
+## Workflow
+
+- After completing a series of code changes, run in this order:
+    1. `pnpm run ws:tsc` and `pnpm run ws:test`
+    2. `pnpm run ws:lint:fix`
+    3. `pnpm run codemod:full` — **before** any doc step, see below
+    4. `pnpm run ws:doc:embed:jsdoc`, then `pnpm run ws:doc:embed`, then
+       `pnpm run ws:doc`
+    5. `pnpm run fmt:full`
+    6. `pnpm run check:root` if you touched the root `scripts/` or `configs/`
+    7. `pnpm run ws:build`
+- **The codemod must run before the doc embeds.** `codemod:full`
+  (`append-as-const` / `convert-to-readonly`) rewrites files under `samples/`,
+  so running it *after* an embed leaves the copy inside the JSDoc block stale
+  — which fails CI's build and doc checks while everything passes locally.
+  This bites whenever a task adds **new** sample files.
+- Run the sequence a second time and confirm `git status` does not grow. These
+  steps feed each other, so one pass is not proof of a fixed point.
+- The JSDoc sample mapping
+  (`packages/ts-fortress/scripts/cmd/embed-examples-in-jsdoc-map.mts`) is
+  **count-exact and order-sensitive per source file**, so splitting or merging
+  a source file breaks the embed even though no example changed.
+
+## The Length-Constrained Array Combinators
+
+`minLengthArray` / `maxLengthArray` / `boundedLengthArray` /
+`fixedLengthArray` in `packages/ts-fortress/src/array/` return the **branded**
+ts-type-forge types, while their `*Tuple` counterparts return the structural
+ones. Two properties are worth knowing before touching them or the ESLint
+rules that rewrite them:
+
+- **The result is a *pure* brand.** These combinators produce
+  `Type<MinLengthArray<N, A>>` and never intersect the brand with a tuple.
+  That is the opposite of ts-data-forge's `Arr.is*` guards, which narrow to
+  `Brand<…> & Xs` so as to keep the caller's own element types. If you are
+  reasoning about "brand intersected with tuple" types, this repository is not
+  a source of them.
+- **Each combinator is an overload pair keyed on the bound.** A bound inside
+  `SupportedLength` (`0..2048`) can be encoded in the brand; anything larger
+  selects the fallback overload and the length constraint is dropped
+  (`Type<readonly A[]>`). The structural `*Tuple` combinators have the tighter
+  `StructuralPrefixLength` (`0..10`) limit, mirrored as
+  `STRUCTURAL_PREFIX_CAP` in the plugin's `constants.mts`. A rewrite that
+  carries a bound from one combinator to another is only valid while the bound
+  is inside the target's range.
+
+### Why canonical-form rewrites must be type-identical here
+
+`prefer-canonical-length-constrained-type` only rewrites calls whose result is
+the **very same** `Type<T>`, never one that is merely narrower. That is
+stricter than the equivalent ts-data-forge rules, and the reason is variance:
+`Type<A>` is **not covariant in `A`** (`prune` takes `<B extends A>`, putting
+`A` in a constraint position — see the long note on `Type` in
+`src/type.mts`). So a `Type<Narrower>` is *not* substitutable for a
+`Type<Wider>`, and "strengthening" a combinator call can break assignability
+at every use site.
+
+A ts-data-forge `Arr.as*` cast has no such problem — it only ever *returns*
+the narrowed value, so a strengthened result stays assignable everywhere the
+old one was, and those rules do allow a few strengthening rewrites. Do not
+port that latitude back here.
+
 ## Validation Error Handling
 
 ### Centralized Error Message Logic


### PR DESCRIPTION
Documentation only — `agents/local-rules.md` plus the `AGENTS.md` it generates. No source or test changes.

## What's recorded

**This repository is not a source of "brand intersected with tuple" types.** Auditing where such types come from across ts-type-forge / ts-data-forge / ts-fortress established that the array combinators here return a pure `Type<MinLengthArray<N, A>>` — unlike ts-data-forge's `Arr.is*` guards, which narrow to `Brand<…> & Xs` in order to keep the caller's element types. Worth writing down, because the question comes up whenever the branded length family is touched and the answer is not obvious from either side.

**Each combinator is an overload pair keyed on the bound.** A bound inside `SupportedLength` (`0..2048`) can be encoded in the brand; anything larger selects the fallback overload and the constraint is dropped. The structural `*Tuple` combinators have the tighter `StructuralPrefixLength` (`0..10`) limit, mirrored as `STRUCTURAL_PREFIX_CAP` in the plugin's `constants.mts`. A rewrite may only carry a bound to another combinator while it stays inside the target's range.

**Why `prefer-canonical-length-constrained-type` insists on type-identical rewrites.** `Type<A>` is not covariant in `A` — `prune` takes `<B extends A>`, putting `A` in a constraint position (the reasoning is already spelled out on `Type` in `src/type.mts`, but the *consequence for the ESLint rules* was not written down anywhere). So a `Type<Narrower>` is not substitutable for a `Type<Wider>`, and a "strengthening" rewrite can break assignability at every use site.

The equivalent ts-data-forge rules do allow a few strengthening rewrites, because a cast only ever *returns* the narrowed value and stays assignable everywhere the old one was. The note makes explicit that this latitude must not be ported back here.

**The workflow section the other two repositories already have.** `codemod:full` rewrites files under `samples/`, so it has to run before the doc embeds or the copy inside the JSDoc block is left stale — passing locally and failing in CI. Also that one pass is not proof of a fixed point, and that the JSDoc sample mapping is count-exact and order-sensitive per source file.

## Test plan

- [x] `pnpm run agents:gen` — `AGENTS.md` regenerated, no drift
- [x] `pnpm run md`, `pnpm run cspell`, `pnpm run fmt` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4)_