### PR TITLE
fix(array)!: order the combinators' type params to match their arguments

### DIFF
--- a/.changeset/combinator-type-param-order.md
+++ b/.changeset/combinator-type-param-order.md
@@ -1,0 +1,39 @@
+---
+'ts-fortress': major
+---
+
+**The array combinators' type parameters now follow their arguments.**
+
+`minLengthArray` and its seven siblings declared `<A, N>` while both the
+argument list and the result put the length first:
+
+```ts
+// before
+export function minLengthArray<A, N extends SupportedLength>(
+  minLength: N,
+  elementType: Type<A>,
+  ...
+): Type<MinLengthArray<N, A>>;
+```
+
+The declaration was the only part out of step — an explicit type-argument list
+read in the opposite order from the call it annotated, and from the
+`MinLengthArray<N, A>` it produced. All eight now declare the length first:
+
+| combinator                                  | before          | after           |
+| :------------------------------------------ | :-------------- | :-------------- |
+| `minLengthArray` / `minLengthTuple`         | `<A, N>`        | `<N, A>`        |
+| `maxLengthArray` / `maxLengthTuple`         | `<A, N>`        | `<N, A>`        |
+| `fixedLengthArray` / `fixedLengthTuple`     | `<A, N>`        | `<N, A>`        |
+| `boundedLengthArray` / `boundedLengthTuple` | `<A, Min, Max>` | `<Min, Max, A>` |
+
+This also lines the repository up with ts-data-forge, whose `Arr.is*` / `Arr.as*`
+and `Str.is*` / `Str.as*` families follow the same rule, and with the
+ts-type-forge types being produced, which are length-first throughout
+(`MinLengthArray<MinLength, Elm>`, `BoundedLengthTuple<Min, Max, Elm>`).
+
+BREAKING CHANGE: only call sites that pass explicit type arguments to these
+eight combinators are affected — `t.minLengthArray<string, 3>(3, t.string)`
+becomes `t.minLengthArray<3, string>(3, t.string)`. Both parameters are
+inferred from the arguments in ordinary use, so a call written without explicit
+type arguments needs no change.

--- a/packages/ts-fortress/src/array/bounded-length-array.mts
+++ b/packages/ts-fortress/src/array/bounded-length-array.mts
@@ -24,9 +24,9 @@ export type { BoundedLengthArray } from 'ts-type-forge';
  * even when `A` is a large type.
  */
 export function boundedLengthArray<
-  A,
   Min extends SupportedLength,
   Max extends SupportedLength,
+  A,
 >(
   min: Min,
   max: Max,
@@ -41,7 +41,7 @@ export function boundedLengthArray<
 
 // Only the lower bound is in `SupportedLength`, so the upper bound is dropped from
 // the result type and only the "at least `min`" guarantee is kept.
-export function boundedLengthArray<A, Min extends SupportedLength>(
+export function boundedLengthArray<Min extends SupportedLength, A>(
   min: Min,
   max: number,
   elementType: Type<A>,
@@ -55,7 +55,7 @@ export function boundedLengthArray<A, Min extends SupportedLength>(
 
 // Only the upper bound is in `SupportedLength`, so the lower bound is dropped from
 // the result type and only the "at most `max`" guarantee is kept.
-export function boundedLengthArray<A, Max extends SupportedLength>(
+export function boundedLengthArray<Max extends SupportedLength, A>(
   min: number,
   max: Max,
   elementType: Type<A>,

--- a/packages/ts-fortress/src/array/bounded-length-tuple.mts
+++ b/packages/ts-fortress/src/array/bounded-length-tuple.mts
@@ -18,9 +18,9 @@ import {
 export type { BoundedLengthTuple } from 'ts-type-forge';
 
 export function boundedLengthTuple<
-  A,
   Min extends StructuralPrefixLength,
   Max extends StructuralPrefixLength,
+  A,
 >(
   min: Min,
   max: Max,
@@ -35,7 +35,7 @@ export function boundedLengthTuple<
 
 // Only the lower bound is in `StructuralPrefixLength` (`0..10`), so the upper bound is dropped from the
 // result type and only the "at least `min`" guarantee is kept.
-export function boundedLengthTuple<A, Min extends StructuralPrefixLength>(
+export function boundedLengthTuple<Min extends StructuralPrefixLength, A>(
   min: Min,
   max: number,
   elementType: Type<A>,
@@ -49,7 +49,7 @@ export function boundedLengthTuple<A, Min extends StructuralPrefixLength>(
 
 // Only the upper bound is in `StructuralPrefixLength` (`0..10`), so the lower bound is dropped from the
 // result type and only the "at most `max`" guarantee is kept.
-export function boundedLengthTuple<A, Max extends StructuralPrefixLength>(
+export function boundedLengthTuple<Max extends StructuralPrefixLength, A>(
   min: number,
   max: Max,
   elementType: Type<A>,

--- a/packages/ts-fortress/src/array/fixed-length-array.mts
+++ b/packages/ts-fortress/src/array/fixed-length-array.mts
@@ -20,7 +20,7 @@ export type { FixedLengthArray } from 'ts-type-forge';
  * large; prefer `fixedLengthTuple` when positional element types or a literal
  * `length` are needed.
  */
-export function fixedLengthArray<A, N extends SupportedLength>(
+export function fixedLengthArray<N extends SupportedLength, A>(
   size: N,
   elementType: Type<A>,
   options?: Partial<

--- a/packages/ts-fortress/src/array/fixed-length-tuple.mts
+++ b/packages/ts-fortress/src/array/fixed-length-tuple.mts
@@ -15,7 +15,7 @@ import {
 
 export type { FixedLengthTuple } from 'ts-type-forge';
 
-export const fixedLengthTuple = <A, N extends StructuralPrefixLength>(
+export const fixedLengthTuple = <N extends StructuralPrefixLength, A>(
   size: N,
   elementType: Type<A>,
   options?: Partial<

--- a/packages/ts-fortress/src/array/max-length-array.mts
+++ b/packages/ts-fortress/src/array/max-length-array.mts
@@ -18,7 +18,7 @@ export type { MaxLengthArray } from 'ts-type-forge';
  * of the element type is ever constructed, which keeps type-checking cheap
  * even when `A` is a large type.
  */
-export function maxLengthArray<A, N extends SupportedLength>(
+export function maxLengthArray<N extends SupportedLength, A>(
   maxLength: N,
   elementType: Type<A>,
   options?: Partial<

--- a/packages/ts-fortress/src/array/max-length-tuple.mts
+++ b/packages/ts-fortress/src/array/max-length-tuple.mts
@@ -15,7 +15,7 @@ import {
 
 export type { MaxLengthTuple } from 'ts-type-forge';
 
-export function maxLengthTuple<A, N extends StructuralPrefixLength>(
+export function maxLengthTuple<N extends StructuralPrefixLength, A>(
   size: N,
   elementType: Type<A>,
   options?: Partial<

--- a/packages/ts-fortress/src/array/min-length-array.mts
+++ b/packages/ts-fortress/src/array/min-length-array.mts
@@ -18,7 +18,7 @@ export type { MinLengthArray } from 'ts-type-forge';
  * never expanded into tuple positions, which keeps type-checking cheap even
  * when `A` is a large type.
  */
-export function minLengthArray<A, N extends SupportedLength>(
+export function minLengthArray<N extends SupportedLength, A>(
   minLength: N,
   elementType: Type<A>,
   options?: Partial<

--- a/packages/ts-fortress/src/array/min-length-tuple.mts
+++ b/packages/ts-fortress/src/array/min-length-tuple.mts
@@ -15,7 +15,7 @@ import {
 
 export type { MinLengthTuple } from 'ts-type-forge';
 
-export function minLengthTuple<A, N extends StructuralPrefixLength>(
+export function minLengthTuple<N extends StructuralPrefixLength, A>(
   size: N,
   elementType: Type<A>,
   options?: Partial<


### PR DESCRIPTION
## Summary

`minLengthArray` and its seven siblings declared `<A, N>` while both the argument list and the result put the length first:

```ts
export function minLengthArray<A, N extends SupportedLength>(
  minLength: N,
  elementType: Type<A>,
  ...
): Type<MinLengthArray<N, A>>;
```

The declaration was the only part out of step, so an explicit type-argument list read in the opposite order from both the call it annotated and the type it produced. All eight now lead with the length.

| combinator | before | after |
| :--- | :--- | :--- |
| `minLengthArray` / `minLengthTuple` | `<A, N>` | `<N, A>` |
| `maxLengthArray` / `maxLengthTuple` | `<A, N>` | `<N, A>` |
| `fixedLengthArray` / `fixedLengthTuple` | `<A, N>` | `<N, A>` |
| `boundedLengthArray` / `boundedLengthTuple` | `<A, Min, Max>` | `<Min, Max, A>` |

This is the same rule ts-data-forge's `Arr.is*` / `Arr.as*` and `Str.is*` / `Str.as*` families follow, and it matches the ts-type-forge types being produced, which are length-first throughout (`MinLengthArray<MinLength, Elm>`, `BoundedLengthTuple<Min, Max, Elm>`).

## How this was found

An audit across all three repositories, comparing every signature's type-parameter declaration order against the first value parameter that mentions each one. These eight were the only mismatches in this repository; a re-run after the change reports zero.

The same sweep found two in ts-data-forge (`Arr.sumBy`, `Arr.partition`, being fixed in its own major) and two in ts-type-forge (`MakeTuple`, `SetAt`, queued for a separate PR).

## Breaking change

Only call sites that pass explicit type arguments to these eight combinators are affected:

```ts
t.minLengthArray<string, 3>(3, t.string); // before
t.minLengthArray<3, string>(3, t.string); // after
```

Both parameters are inferred from the arguments in ordinary use, so a call written without explicit type arguments needs no change. A changeset marks this `major`.

## Test plan

- [x] `pnpm run ws:tsc` — clean
- [x] `pnpm run ws:test` — 1664 tests pass, plus the ESLint plugin's suite
- [x] `pnpm run ws:build`, `check:root`, `ws:lint:fix`, `codemod:full`, doc embeds, `cspell`, `md`, `fmt:full` — all clean, no file diff on a second pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4)_