### PR TITLE
chore: extend cspell scope to .changeset/.github and disable required code-owner review

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -4,15 +4,18 @@ allowCompoundWords: true
 caseSensitive: false
 ignoreRandomStrings: true
 words:
+  - amannn
+  - anthropics
   - bivariance
   - brandable
   - noshiro
   - sindresorhus
   - testw
-  - tses
   - tscw
+  - tses
   - unshifted
   - valueof
+  - vitest
   - whatwg
 ignorePaths:
   - pnpm-lock.yaml

--- a/github/rulesets/main.json
+++ b/github/rulesets/main.json
@@ -37,7 +37,7 @@
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": true,
         "required_reviewers": [],
-        "require_code_owner_review": true,
+        "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": ["squash"]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "codemod:full:readonly": "convert-to-readonly 'packages/*/{src,scripts,samples,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:as-const": "append-as-const --uncommitted 'packages/*/{src,scripts,samples,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:readonly": "convert-to-readonly --uncommitted 'packages/*/{src,scripts,samples,test}/**/*.{mts,tsx}'",
-    "cspell": "cspell \"**\" --gitignore --gitignore-root ./ --no-progress",
+    "cspell": "cspell \"{**,.changeset/**/*,.github/**/*}\" --gitignore --gitignore-root ./ --no-progress",
     "fmt": "format-uncommitted",
     "fmt:diff": "format-diff-from origin/main",
     "fmt:full": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write .",


### PR DESCRIPTION
## Changes

- **cspell**: extend the scan glob to include `.changeset/**/*` and `.github/**/*` (previously excluded), so changeset files and workflow files are spell-checked going forward.
- **cspell dictionary**: add `amannn anthropics vitest` — words newly surfaced by the wider scan.
- **ruleset**: set `require_code_owner_review` to `false` in `github/rulesets/main.json` (was blocking Dependabot auto-merge). Only the active ruleset file is changed; `bk/` is a regenerated backup snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)