### PR TITLE
chore(ci): drop the retired release App from the main ruleset bypass actors

### DIFF
--- a/github/rulesets/main.json
+++ b/github/rulesets/main.json
@@ -8,11 +8,6 @@
       "actor_id": 5,
       "actor_type": "RepositoryRole",
       "bypass_mode": "always"
-    },
-    {
-      "actor_id": 1442563,
-      "actor_type": "Integration",
-      "bypass_mode": "always"
     }
   ],
   "conditions": {


### PR DESCRIPTION
main ruleset の bypass actor に `noshiro-semantic-release-bot`（ App 1442563 ）が登録されていますが、このリポジトリでは main へリリースコミットを push しないため使われていません。

廃止予定の App への dangling な Integration 参照を残さないよう、付け替えではなく削除します。

**merge しただけでは反映されません** — `repo-settings apply rulesets` の実行が必要です。